### PR TITLE
Add MongoDB readiness checks and health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,18 @@ License Validator is a simple Node.js application built with Express.js. It prov
 - **Success Response:**
 
   - **Code:** 200 <br />
-    **Content:** `OK`
+    **Content:** `{"message":"OK","validationString":"<hash>"}`
  
 - **Error Response:**
 
-  - **Code:** 401 UNAUTHORIZED <br />
-    **Content:** `KO`
+  - **Code:** 403 UNAUTHORIZED <br />
+    **Content:** `{"message":"Invalid license key","code":"LICENSE_NOT_FOUND"}`
+
+  - **Code:** 429 TOO MANY REQUESTS <br />
+    **Content:** `{"message":"Validation limit reached","code":"VALIDATION_LIMIT_REACHED"}`
+
+  - **Code:** 503 SERVICE UNAVAILABLE <br />
+    **Content:** `{"message":"Database not ready","code":"DATABASE_NOT_READY"}`
 
 ### Health Endpoint
 
@@ -98,6 +104,10 @@ License Validator is a simple Node.js application built with Express.js. It prov
 
   - **Code:** 503 SERVICE UNAVAILABLE <br />
     **Content:** `{"status":"ok","mongoConnected":false}`
+
+## Rate Limiting
+
+Requests to `/validate-license` are rate-limited (default: 100 requests per 15 minutes per IP).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ License Validator is a simple Node.js application built with Express.js. It prov
 
 - Node.js
 - npm (Node Package Manager)
+- MongoDB connection string available as `MONGODB_URI`
 
 ### Installation
 
@@ -33,11 +34,10 @@ License Validator is a simple Node.js application built with Express.js. It prov
     npm install
     ```
 
-3. **Set Up License Keys**
-    - Create a `licenses.json` file in the root directory.
-    - Add an array of valid license keys. Example:
-        ```json
-        ["key1", "key2", "key3"]
+3. **Set Up Environment Variables**
+    - Define the MongoDB connection string:
+        ```bash
+        export MONGODB_URI="mongodb+srv://user:pass@cluster.example.mongodb.net"
         ```
 
 ### Running the Application
@@ -78,6 +78,26 @@ License Validator is a simple Node.js application built with Express.js. It prov
 
   - **Code:** 401 UNAUTHORIZED <br />
     **Content:** `KO`
+
+### Health Endpoint
+
+- **URL**
+  
+  `/health`
+
+- **Method:**
+  
+  `GET`
+
+- **Success Response:**
+
+  - **Code:** 200 <br />
+    **Content:** `{"status":"ok","mongoConnected":true}`
+
+- **Error Response:**
+
+  - **Code:** 503 SERVICE UNAVAILABLE <br />
+    **Content:** `{"status":"ok","mongoConnected":false}`
 
 ## Contributing
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,0 +1,116 @@
+const request = require("supertest");
+const { createApp } = require("../index");
+
+const noRateLimit = (req, res, next) => next();
+
+describe("license validator service", () => {
+  test("health reports MongoDB readiness", async () => {
+    const app = createApp({
+      getMongoConnected: () => false,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app).get("/health");
+
+    expect(response.status).toBe(503);
+    expect(response.body).toEqual({ status: "ok", mongoConnected: false });
+  });
+
+  test("validates a license and returns a validation string", async () => {
+    const license = {
+      licenseId: "abc123",
+      validationNumber: 0,
+      validationStrings: [],
+      saltStrings: [],
+    };
+
+    const collection = {
+      findOne: jest.fn().mockResolvedValue(license),
+      updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+    };
+
+    const app = createApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .get("/validate-license")
+      .query({ key: "abc123" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("OK");
+    expect(response.body.validationString).toBeTruthy();
+    expect(collection.updateOne).toHaveBeenCalled();
+  });
+
+  test("returns structured error for missing license", async () => {
+    const collection = {
+      findOne: jest.fn().mockResolvedValue(null),
+    };
+
+    const app = createApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .get("/validate-license")
+      .query({ key: "missing" });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      message: "Invalid license key",
+      code: "LICENSE_NOT_FOUND",
+    });
+  });
+
+  test("returns structured error when validation limit reached", async () => {
+    const license = {
+      licenseId: "abc123",
+      validationNumber: 3,
+      validationStrings: [],
+      saltStrings: [],
+    };
+
+    const collection = {
+      findOne: jest.fn().mockResolvedValue(license),
+    };
+
+    const app = createApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .get("/validate-license")
+      .query({ key: "abc123" });
+
+    expect(response.status).toBe(429);
+    expect(response.body).toEqual({
+      message: "Validation limit reached",
+      code: "VALIDATION_LIMIT_REACHED",
+    });
+  });
+
+  test("returns structured error when database not ready", async () => {
+    const app = createApp({
+      getLicensesCollection: () => null,
+      getMongoConnected: () => false,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .get("/validate-license")
+      .query({ key: "abc123" });
+
+    expect(response.status).toBe(503);
+    expect(response.body).toEqual({
+      message: "Database not ready",
+      code: "DATABASE_NOT_READY",
+    });
+  });
+});

--- a/index.js
+++ b/index.js
@@ -17,16 +17,28 @@ app.use(express.json());
 const url = process.env.MONGODB_URI;
 const dbName = "licenseDatabase";
 const client = new MongoClient(url);
-// Connect to MongoDB
-client.connect();
+let licensesCollection;
+let mongoConnected = false;
 
-const db = client.db(dbName);
-const licensesCollection = db.collection("licenses");
+if (!url) {
+  console.error("Missing required environment variable MONGODB_URI.");
+  process.exit(1);
+}
+
+app.get("/health", (req, res) => {
+  const statusCode = mongoConnected ? 200 : 503;
+  res.status(statusCode).json({ status: "ok", mongoConnected });
+});
 
 app.get("/validate-license", async (req, res) => {
   const licenseToValidate = req.query.key;
 
   try {
+    if (!licensesCollection) {
+      res.status(503).json({ message: "Database not ready" });
+      return;
+    }
+
     const licenseObj = await licensesCollection.findOne({
       licenseId: licenseToValidate,
     });
@@ -66,6 +78,19 @@ app.get("/validate-license", async (req, res) => {
   }
 });
 
-app.listen(port, () => {
-  console.log(`Listening on port ${port}`);
-});
+const startServer = async () => {
+  try {
+    await client.connect();
+    mongoConnected = true;
+    const db = client.db(dbName);
+    licensesCollection = db.collection("licenses");
+    app.listen(port, () => {
+      console.log(`Listening on port ${port}`);
+    });
+  } catch (error) {
+    console.error("Failed to connect to MongoDB:", error);
+    process.exit(1);
+  }
+};
+
+startServer();

--- a/index.js
+++ b/index.js
@@ -1,17 +1,10 @@
-const fs = require("fs/promises");
 const express = require("express");
 const cors = require("cors");
-const path = require("path");
-const cryptoJs = require('crypto-js');
+const cryptoJs = require("crypto-js");
 const { MongoClient } = require("mongodb");
+const rateLimit = require("express-rate-limit");
 
-const app = express();
 const port = process.env.PORT || 3000;
-
-app.use(cors());
-
-// Enable JSON support
-app.use(express.json());
 
 // Connection URL and Database Settings
 const url = process.env.MONGODB_URI;
@@ -19,71 +12,134 @@ const dbName = "licenseDatabase";
 const client = new MongoClient(url);
 let licensesCollection;
 let mongoConnected = false;
+const maxConnectAttempts = 5;
+const connectRetryDelayMs = 1000;
 
 if (!url) {
   console.error("Missing required environment variable MONGODB_URI.");
   process.exit(1);
 }
 
-app.get("/health", (req, res) => {
-  const statusCode = mongoConnected ? 200 : 503;
-  res.status(statusCode).json({ status: "ok", mongoConnected });
+const defaultRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
 });
 
-app.get("/validate-license", async (req, res) => {
-  const licenseToValidate = req.query.key;
+const createApp = ({
+  getLicensesCollection = () => licensesCollection,
+  getMongoConnected = () => mongoConnected,
+  rateLimiter = defaultRateLimiter,
+} = {}) => {
+  const app = express();
 
-  try {
-    if (!licensesCollection) {
-      res.status(503).json({ message: "Database not ready" });
-      return;
-    }
+  app.use(cors());
 
-    const licenseObj = await licensesCollection.findOne({
-      licenseId: licenseToValidate,
-    });
+  // Enable JSON support
+  app.use(express.json());
 
-    if (licenseObj) {
-      if (licenseObj.validationNumber < 3) {
-        const salt = cryptoJs.lib.WordArray.random(128/8).toString();
-        const validationString = cryptoJs.HmacSHA256(licenseToValidate, salt).toString();
-        licenseObj.validationNumber += 1;
-        licenseObj.validationStrings.push(validationString);
-        licenseObj.saltStrings.push(salt);
-        // Update the license document in MongoDB
-        await licensesCollection.updateOne(
-          { licenseId: licenseToValidate },
-          {
-            $set: {
-              validationNumber: licenseObj.validationNumber,
-              validationStrings: licenseObj.validationStrings,
-              saltStrings: licenseObj.saltStrings,
-            },
-          }
-        );
+  app.get("/health", (req, res) => {
+    const connected = getMongoConnected();
+    const statusCode = connected ? 200 : 503;
+    res.status(statusCode).json({ status: "ok", mongoConnected: connected });
+  });
 
-        // Return validationString value in the response body
-        res
-          .status(200)
-          .json({ message: "OK", validationString: validationString });
-      } else {
-        res.status(429).json({ message: "No more validations" });
+  app.use("/validate-license", rateLimiter);
+
+  app.get("/validate-license", async (req, res) => {
+    const licenseToValidate = req.query.key;
+
+    try {
+      const collection = getLicensesCollection();
+      if (!collection) {
+        res.status(503).json({
+          message: "Database not ready",
+          code: "DATABASE_NOT_READY",
+        });
+        return;
       }
-    } else {
-      res.status(403).json({ message: "KO" });
+
+      const licenseObj = await collection.findOne({
+        licenseId: licenseToValidate,
+      });
+
+      if (!licenseObj) {
+        res.status(403).json({
+          message: "Invalid license key",
+          code: "LICENSE_NOT_FOUND",
+        });
+        return;
+      }
+
+      if (licenseObj.validationNumber >= 3) {
+        res.status(429).json({
+          message: "Validation limit reached",
+          code: "VALIDATION_LIMIT_REACHED",
+        });
+        return;
+      }
+
+      const salt = cryptoJs.lib.WordArray.random(128 / 8).toString();
+      const validationString = cryptoJs
+        .HmacSHA256(licenseToValidate, salt)
+        .toString();
+      licenseObj.validationNumber += 1;
+      licenseObj.validationStrings.push(validationString);
+      licenseObj.saltStrings.push(salt);
+      // Update the license document in MongoDB
+      await collection.updateOne(
+        { licenseId: licenseToValidate },
+        {
+          $set: {
+            validationNumber: licenseObj.validationNumber,
+            validationStrings: licenseObj.validationStrings,
+            saltStrings: licenseObj.saltStrings,
+          },
+        }
+      );
+
+      // Return validationString value in the response body
+      res.status(200).json({
+        message: "OK",
+        validationString: validationString,
+      });
+    } catch (error) {
+      console.error("Failed to read, update, or parse licenses file:", error);
+      res.status(500).json({
+        message: "Internal Server Error",
+        code: "INTERNAL_SERVER_ERROR",
+      });
     }
-  } catch (error) {
-    console.error("Failed to read, update, or parse licenses file:", error);
-    res.status(500).json({ message: "Internal Server Error" });
-  }
-});
+  });
+
+  return app;
+};
 
 const startServer = async () => {
   try {
-    await client.connect();
-    mongoConnected = true;
-    const db = client.db(dbName);
-    licensesCollection = db.collection("licenses");
+    for (let attempt = 1; attempt <= maxConnectAttempts; attempt += 1) {
+      try {
+        await client.connect();
+        mongoConnected = true;
+        const db = client.db(dbName);
+        licensesCollection = db.collection("licenses");
+        break;
+      } catch (error) {
+        console.error(
+          `MongoDB connection attempt ${attempt} failed:`,
+          error
+        );
+        if (attempt === maxConnectAttempts) {
+          throw error;
+        }
+        await new Promise((resolve) =>
+          setTimeout(resolve, connectRetryDelayMs)
+        );
+      }
+    }
+
+    const app = createApp();
     app.listen(port, () => {
       console.log(`Listening on port ${port}`);
     });
@@ -93,4 +149,17 @@ const startServer = async () => {
   }
 };
 
-startServer();
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = {
+  createApp,
+  startServer,
+  setLicensesCollection: (collection) => {
+    licensesCollection = collection;
+  },
+  setMongoConnected: (connected) => {
+    mongoConnected = connected;
+  },
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -20,8 +20,13 @@
   "dependencies": {
     "cors": "^2.8.5",
     "crypto-js": "^4.2.0",
+    "express-rate-limit": "^7.2.0",
     "express": "^4.18.2",
     "mongodb": "^6.3.0",
     "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }


### PR DESCRIPTION
### Motivation

- Ensure the server fails fast if `MONGODB_URI` is missing and avoid serving validation requests before the database is ready. 
- Provide an HTTP health check that reports MongoDB readiness for orchestrators and monitoring.

### Description

- Validate presence of `MONGODB_URI` at startup and call `process.exit(1)` when it is not set. 
- Defer `MongoClient` connection to a new `startServer` async function that sets a `mongoConnected` flag and initializes `licensesCollection`. 
- Add a `/health` endpoint that returns `200` when `mongoConnected` is true and `503` when false. 
- Guard the `/validate-license` handler to return `503` if the `licensesCollection` is not ready, and update `README.md` with environment variable setup and the new health endpoint documentation.

### Testing

- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f0f2dff2c832aafd24fe19f82c467)