### PR TITLE
[codex] Add license key validation safety

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -16,6 +16,96 @@ describe("license validator service", () => {
     expect(response.body).toEqual({ status: "ok", mongoConnected: false });
   });
 
+  test("returns structured error when license key is missing", async () => {
+    const collection = {
+      findOne: jest.fn(),
+    };
+
+    const app = createApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app).get("/validate-license");
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      message: "License key is required",
+      code: "MISSING_LICENSE_KEY",
+    });
+    expect(collection.findOne).not.toHaveBeenCalled();
+  });
+
+  test("returns structured error when license key is empty", async () => {
+    const collection = {
+      findOne: jest.fn(),
+    };
+
+    const app = createApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .get("/validate-license")
+      .query({ key: "" });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      message: "License key is required",
+      code: "MISSING_LICENSE_KEY",
+    });
+    expect(collection.findOne).not.toHaveBeenCalled();
+  });
+
+  test("returns structured error when license key is whitespace only", async () => {
+    const collection = {
+      findOne: jest.fn(),
+    };
+
+    const app = createApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .get("/validate-license")
+      .query({ key: "   " });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      message: "License key is required",
+      code: "MISSING_LICENSE_KEY",
+    });
+    expect(collection.findOne).not.toHaveBeenCalled();
+  });
+
+  test("returns structured error when license key is not a simple string", async () => {
+    const collection = {
+      findOne: jest.fn(),
+    };
+
+    const app = createApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app).get(
+      "/validate-license?key=abc123&key=def456"
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      message: "Invalid license key",
+      code: "INVALID_LICENSE_KEY",
+    });
+    expect(collection.findOne).not.toHaveBeenCalled();
+  });
+
   test("validates a license and returns a validation string", async () => {
     const license = {
       licenseId: "abc123",

--- a/index.js
+++ b/index.js
@@ -6,19 +6,11 @@ const rateLimit = require("express-rate-limit");
 
 const port = process.env.PORT || 3000;
 
-// Connection URL and Database Settings
-const url = process.env.MONGODB_URI;
 const dbName = "licenseDatabase";
-const client = new MongoClient(url);
 let licensesCollection;
 let mongoConnected = false;
 const maxConnectAttempts = 5;
 const connectRetryDelayMs = 1000;
-
-if (!url) {
-  console.error("Missing required environment variable MONGODB_URI.");
-  process.exit(1);
-}
 
 const defaultRateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -26,6 +18,38 @@ const defaultRateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
 });
+
+const getValidLicenseKey = (key) => {
+  if (key === undefined) {
+    return {
+      error: {
+        message: "License key is required",
+        code: "MISSING_LICENSE_KEY",
+      },
+    };
+  }
+
+  if (typeof key !== "string") {
+    return {
+      error: {
+        message: "Invalid license key",
+        code: "INVALID_LICENSE_KEY",
+      },
+    };
+  }
+
+  const trimmedKey = key.trim();
+  if (!trimmedKey) {
+    return {
+      error: {
+        message: "License key is required",
+        code: "MISSING_LICENSE_KEY",
+      },
+    };
+  }
+
+  return { value: trimmedKey };
+};
 
 const createApp = ({
   getLicensesCollection = () => licensesCollection,
@@ -48,7 +72,14 @@ const createApp = ({
   app.use("/validate-license", rateLimiter);
 
   app.get("/validate-license", async (req, res) => {
-    const licenseToValidate = req.query.key;
+    const { value: licenseToValidate, error: keyError } = getValidLicenseKey(
+      req.query.key
+    );
+
+    if (keyError) {
+      res.status(400).json(keyError);
+      return;
+    }
 
     try {
       const collection = getLicensesCollection();
@@ -105,7 +136,7 @@ const createApp = ({
         validationString: validationString,
       });
     } catch (error) {
-      console.error("Failed to read, update, or parse licenses file:", error);
+      console.error("Failed to read or update license in MongoDB:", error);
       res.status(500).json({
         message: "Internal Server Error",
         code: "INTERNAL_SERVER_ERROR",
@@ -117,6 +148,15 @@ const createApp = ({
 };
 
 const startServer = async () => {
+  const url = process.env.MONGODB_URI;
+
+  if (!url) {
+    console.error("Missing required environment variable MONGODB_URI.");
+    process.exit(1);
+  }
+
+  const client = new MongoClient(url);
+
   try {
     for (let attempt = 1; attempt <= maxConnectAttempts; attempt += 1) {
       try {


### PR DESCRIPTION
## Summary

- Move MongoDB client creation and `MONGODB_URI` validation out of module import paths and into direct server startup.
- Add explicit `GET /validate-license` key validation for missing, empty, whitespace-only, and repeated/non-string query values.
- Update the misleading license-file error log to describe MongoDB license update failures.
- Add Jest/Supertest coverage for invalid key handling while preserving existing valid, missing-license, limit-reached, database-not-ready, and health behavior.

## Validation

- `npm test` passed: 9 tests, 1 suite.
- Verified `require('./index')` works without `MONGODB_URI`.
- Verified `node index.js` still fails fast when `MONGODB_URI` is missing.

## Notes

This PR intentionally does not add POST validation, atomic MongoDB updates, crypto changes, CORS changes, rate-limit changes, or Vercel behavior changes. Those remain follow-up work from the update plan.