### PR TITLE
[codex] Make license validation atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ License Validator is a simple Node.js application built with Express.js. It prov
 2. **Access the Endpoint**
     - Validate a license key by navigating to `http://localhost:3000/validate-license?key=your_license_key`.
 
+## MongoDB Collection
+
+The service expects licenses in the `licenseDatabase.licenses` collection. Create a unique index on `licenseId` so each key maps to exactly one document and validation behavior is deterministic:
+
+```js
+db.licenses.createIndex({ licenseId: 1 }, { unique: true })
+```
+
+Expected document shape:
+
+```js
+{
+  licenseId: "example-license-key",
+  validationNumber: 0,
+  validationStrings: [],
+  saltStrings: []
+}
+```
+
 ## API Reference
 
 ### Validate License Endpoint

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -19,6 +19,7 @@ describe("license validator service", () => {
   test("returns structured error when license key is missing", async () => {
     const collection = {
       findOne: jest.fn(),
+      findOneAndUpdate: jest.fn(),
     };
 
     const app = createApp({
@@ -35,11 +36,13 @@ describe("license validator service", () => {
       code: "MISSING_LICENSE_KEY",
     });
     expect(collection.findOne).not.toHaveBeenCalled();
+    expect(collection.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
   test("returns structured error when license key is empty", async () => {
     const collection = {
       findOne: jest.fn(),
+      findOneAndUpdate: jest.fn(),
     };
 
     const app = createApp({
@@ -58,11 +61,13 @@ describe("license validator service", () => {
       code: "MISSING_LICENSE_KEY",
     });
     expect(collection.findOne).not.toHaveBeenCalled();
+    expect(collection.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
   test("returns structured error when license key is whitespace only", async () => {
     const collection = {
       findOne: jest.fn(),
+      findOneAndUpdate: jest.fn(),
     };
 
     const app = createApp({
@@ -81,11 +86,13 @@ describe("license validator service", () => {
       code: "MISSING_LICENSE_KEY",
     });
     expect(collection.findOne).not.toHaveBeenCalled();
+    expect(collection.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
   test("returns structured error when license key is not a simple string", async () => {
     const collection = {
       findOne: jest.fn(),
+      findOneAndUpdate: jest.fn(),
     };
 
     const app = createApp({
@@ -104,19 +111,20 @@ describe("license validator service", () => {
       code: "INVALID_LICENSE_KEY",
     });
     expect(collection.findOne).not.toHaveBeenCalled();
+    expect(collection.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
-  test("validates a license and returns a validation string", async () => {
+  test("validates a license with an atomic update and returns a validation string", async () => {
     const license = {
       licenseId: "abc123",
-      validationNumber: 0,
+      validationNumber: 1,
       validationStrings: [],
       saltStrings: [],
     };
 
     const collection = {
-      findOne: jest.fn().mockResolvedValue(license),
-      updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+      findOne: jest.fn(),
+      findOneAndUpdate: jest.fn().mockResolvedValue(license),
     };
 
     const app = createApp({
@@ -132,11 +140,26 @@ describe("license validator service", () => {
     expect(response.status).toBe(200);
     expect(response.body.message).toBe("OK");
     expect(response.body.validationString).toBeTruthy();
-    expect(collection.updateOne).toHaveBeenCalled();
+    expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
+      {
+        licenseId: "abc123",
+        validationNumber: { $lt: 3 },
+      },
+      {
+        $inc: { validationNumber: 1 },
+        $push: {
+          validationStrings: response.body.validationString,
+          saltStrings: expect.any(String),
+        },
+      },
+      { returnDocument: "after" }
+    );
+    expect(collection.findOne).not.toHaveBeenCalled();
   });
 
   test("returns structured error for missing license", async () => {
     const collection = {
+      findOneAndUpdate: jest.fn().mockResolvedValue(null),
       findOne: jest.fn().mockResolvedValue(null),
     };
 
@@ -155,6 +178,18 @@ describe("license validator service", () => {
       message: "Invalid license key",
       code: "LICENSE_NOT_FOUND",
     });
+    expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
+      {
+        licenseId: "missing",
+        validationNumber: { $lt: 3 },
+      },
+      expect.objectContaining({
+        $inc: { validationNumber: 1 },
+        $push: expect.any(Object),
+      }),
+      { returnDocument: "after" }
+    );
+    expect(collection.findOne).toHaveBeenCalledWith({ licenseId: "missing" });
   });
 
   test("returns structured error when validation limit reached", async () => {
@@ -166,6 +201,7 @@ describe("license validator service", () => {
     };
 
     const collection = {
+      findOneAndUpdate: jest.fn().mockResolvedValue(null),
       findOne: jest.fn().mockResolvedValue(license),
     };
 
@@ -184,6 +220,66 @@ describe("license validator service", () => {
       message: "Validation limit reached",
       code: "VALIDATION_LIMIT_REACHED",
     });
+  });
+
+  test("returns safe error when atomic update does not apply below the limit", async () => {
+    const license = {
+      licenseId: "abc123",
+      validationNumber: 1,
+      validationStrings: [],
+      saltStrings: [],
+    };
+
+    const collection = {
+      findOneAndUpdate: jest.fn().mockResolvedValue(null),
+      findOne: jest.fn().mockResolvedValue(license),
+    };
+
+    const app = createApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .get("/validate-license")
+      .query({ key: "abc123" });
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      message: "Internal Server Error",
+      code: "LICENSE_UPDATE_FAILED",
+    });
+  });
+
+  test("returns structured error when MongoDB update throws", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const collection = {
+      findOneAndUpdate: jest.fn().mockRejectedValue(new Error("write failed")),
+      findOne: jest.fn(),
+    };
+
+    const app = createApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .get("/validate-license")
+      .query({ key: "abc123" });
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      message: "Internal Server Error",
+      code: "INTERNAL_SERVER_ERROR",
+    });
+    expect(collection.findOne).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
   });
 
   test("returns structured error when database not ready", async () => {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ let licensesCollection;
 let mongoConnected = false;
 const maxConnectAttempts = 5;
 const connectRetryDelayMs = 1000;
+const DEFAULT_VALIDATION_LIMIT = 3;
 
 const defaultRateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -49,6 +50,18 @@ const getValidLicenseKey = (key) => {
   }
 
   return { value: trimmedKey };
+};
+
+const getFindOneAndUpdateDocument = (result) => {
+  if (!result) {
+    return null;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(result, "value")) {
+    return result.value;
+  }
+
+  return result;
 };
 
 const createApp = ({
@@ -91,46 +104,57 @@ const createApp = ({
         return;
       }
 
-      const licenseObj = await collection.findOne({
-        licenseId: licenseToValidate,
-      });
-
-      if (!licenseObj) {
-        res.status(403).json({
-          message: "Invalid license key",
-          code: "LICENSE_NOT_FOUND",
-        });
-        return;
-      }
-
-      if (licenseObj.validationNumber >= 3) {
-        res.status(429).json({
-          message: "Validation limit reached",
-          code: "VALIDATION_LIMIT_REACHED",
-        });
-        return;
-      }
-
       const salt = cryptoJs.lib.WordArray.random(128 / 8).toString();
       const validationString = cryptoJs
         .HmacSHA256(licenseToValidate, salt)
         .toString();
-      licenseObj.validationNumber += 1;
-      licenseObj.validationStrings.push(validationString);
-      licenseObj.saltStrings.push(salt);
-      // Update the license document in MongoDB
-      await collection.updateOne(
-        { licenseId: licenseToValidate },
+
+      const updateResult = await collection.findOneAndUpdate(
         {
-          $set: {
-            validationNumber: licenseObj.validationNumber,
-            validationStrings: licenseObj.validationStrings,
-            saltStrings: licenseObj.saltStrings,
+          licenseId: licenseToValidate,
+          validationNumber: { $lt: DEFAULT_VALIDATION_LIMIT },
+        },
+        {
+          $inc: { validationNumber: 1 },
+          $push: {
+            validationStrings: validationString,
+            saltStrings: salt,
           },
-        }
+        },
+        { returnDocument: "after" }
       );
 
-      // Return validationString value in the response body
+      const updatedLicense = getFindOneAndUpdateDocument(updateResult);
+
+      if (!updatedLicense) {
+        const existingLicense = await collection.findOne({
+          licenseId: licenseToValidate,
+        });
+
+        if (!existingLicense) {
+          res.status(403).json({
+            message: "Invalid license key",
+            code: "LICENSE_NOT_FOUND",
+          });
+          return;
+        }
+
+        if (existingLicense.validationNumber >= DEFAULT_VALIDATION_LIMIT) {
+          res.status(429).json({
+            message: "Validation limit reached",
+            code: "VALIDATION_LIMIT_REACHED",
+          });
+          return;
+        }
+
+        res.status(500).json({
+          message: "Internal Server Error",
+          code: "LICENSE_UPDATE_FAILED",
+        });
+        return;
+      }
+
+      // Return validationString value in the response body only after update.
       res.status(200).json({
         message: "OK",
         validationString: validationString,


### PR DESCRIPTION
## Summary

- Replace the read-then-write license validation flow with a single conditional `findOneAndUpdate` operation.
- Enforce the validation limit in the MongoDB update filter using `validationNumber: { $lt: 3 }`.
- Use `$inc` for `validationNumber` and `$push` for validation metadata.
- Preserve existing API responses by doing a follow-up lookup only when the atomic update does not match a document.
- Document the expected unique `licenseId` index and license document shape in the README.

## Validation

- `npm test` passed: 11 tests, 1 suite.

## Notes

This PR intentionally does not add POST validation, replace `crypto-js`, change CORS, change rate limiting, alter Vercel behavior, remove dependencies, or update package metadata.