### PR TITLE
[codex] Add POST license validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ License Validator is a simple Node.js application built with Express.js. It prov
 - Node.js
 - npm (Node Package Manager)
 - MongoDB connection string available as `MONGODB_URI`
+- HMAC signing secret available as `HMAC_SECRET`
 
 ### Installation
 
@@ -35,9 +36,10 @@ License Validator is a simple Node.js application built with Express.js. It prov
     ```
 
 3. **Set Up Environment Variables**
-    - Define the MongoDB connection string:
+    - Define the MongoDB connection string and HMAC secret:
         ```bash
         export MONGODB_URI="mongodb+srv://user:pass@cluster.example.mongodb.net"
+        export HMAC_SECRET="replace-with-a-long-random-secret"
         ```
 
 ### Running the Application
@@ -49,7 +51,7 @@ License Validator is a simple Node.js application built with Express.js. It prov
     The server will start on `http://localhost:3000`.
 
 2. **Access the Endpoint**
-    - Validate a license key by navigating to `http://localhost:3000/validate-license?key=your_license_key`.
+    - Validate a license key with `POST /validate-license`. New clients should not send license keys in URLs.
 
 ## MongoDB Collection
 
@@ -78,15 +80,31 @@ Expected document shape:
   
   `/validate-license`
 
-- **Method:**
+- **Preferred Method:**
+
+  `POST`
+
+- **Request Body:**
+
+  ```json
+  {
+    "key": "your_license_key"
+  }
+  ```
+
+- **Deprecated Method:**
   
   `GET`
   
 - **URL Params**
 
-   **Required:**
+   **Required for GET only:**
  
    `key=[string]`
+
+- **Deprecation Notice:**
+
+  `GET /validate-license?key=...` remains temporarily supported for backward compatibility, but it is deprecated because license keys in URLs can appear in browser history, logs, analytics, proxies, CDNs, and referrers. GET responses include a deprecation header. Use POST for new integrations.
 
 - **Success Response:**
 
@@ -103,6 +121,12 @@ Expected document shape:
 
   - **Code:** 503 SERVICE UNAVAILABLE <br />
     **Content:** `{"message":"Database not ready","code":"DATABASE_NOT_READY"}`
+
+### Environment Variables
+
+- `MONGODB_URI`: required MongoDB connection string.
+- `HMAC_SECRET`: required server-side secret used to sign validation strings.
+- `PORT`: optional local port; defaults to `3000`.
 
 ### Health Endpoint
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,11 +1,18 @@
 const request = require("supertest");
+const crypto = require("crypto");
 const { createApp } = require("../index");
 
 const noRateLimit = (req, res, next) => next();
+const TEST_HMAC_SECRET = "test-hmac-secret";
+const createTestApp = (options = {}) =>
+  createApp({
+    hmacSecret: TEST_HMAC_SECRET,
+    ...options,
+  });
 
 describe("license validator service", () => {
   test("health reports MongoDB readiness", async () => {
-    const app = createApp({
+    const app = createTestApp({
       getMongoConnected: () => false,
       rateLimiter: noRateLimit,
     });
@@ -22,7 +29,7 @@ describe("license validator service", () => {
       findOneAndUpdate: jest.fn(),
     };
 
-    const app = createApp({
+    const app = createTestApp({
       getLicensesCollection: () => collection,
       getMongoConnected: () => true,
       rateLimiter: noRateLimit,
@@ -45,7 +52,7 @@ describe("license validator service", () => {
       findOneAndUpdate: jest.fn(),
     };
 
-    const app = createApp({
+    const app = createTestApp({
       getLicensesCollection: () => collection,
       getMongoConnected: () => true,
       rateLimiter: noRateLimit,
@@ -70,7 +77,7 @@ describe("license validator service", () => {
       findOneAndUpdate: jest.fn(),
     };
 
-    const app = createApp({
+    const app = createTestApp({
       getLicensesCollection: () => collection,
       getMongoConnected: () => true,
       rateLimiter: noRateLimit,
@@ -95,7 +102,7 @@ describe("license validator service", () => {
       findOneAndUpdate: jest.fn(),
     };
 
-    const app = createApp({
+    const app = createTestApp({
       getLicensesCollection: () => collection,
       getMongoConnected: () => true,
       rateLimiter: noRateLimit,
@@ -114,7 +121,7 @@ describe("license validator service", () => {
     expect(collection.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
-  test("validates a license with an atomic update and returns a validation string", async () => {
+  test("GET validates a license with an atomic update and returns a validation string", async () => {
     const license = {
       licenseId: "abc123",
       validationNumber: 1,
@@ -127,7 +134,7 @@ describe("license validator service", () => {
       findOneAndUpdate: jest.fn().mockResolvedValue(license),
     };
 
-    const app = createApp({
+    const app = createTestApp({
       getLicensesCollection: () => collection,
       getMongoConnected: () => true,
       rateLimiter: noRateLimit,
@@ -140,6 +147,7 @@ describe("license validator service", () => {
     expect(response.status).toBe(200);
     expect(response.body.message).toBe("OK");
     expect(response.body.validationString).toBeTruthy();
+    expect(response.headers.deprecation).toBe("true");
     expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
       {
         licenseId: "abc123",
@@ -154,7 +162,187 @@ describe("license validator service", () => {
       },
       { returnDocument: "after" }
     );
+
+    const update = collection.findOneAndUpdate.mock.calls[0][1];
+    const salt = update.$push.saltStrings;
+    const expectedValidationString = crypto
+      .createHmac("sha256", TEST_HMAC_SECRET)
+      .update(`abc123:${salt}`)
+      .digest("hex");
+    expect(response.body.validationString).toBe(expectedValidationString);
+    expect(response.body.validationString).toMatch(/^[a-f0-9]{64}$/);
     expect(collection.findOne).not.toHaveBeenCalled();
+  });
+
+  test("POST validates a license with the shared atomic update flow", async () => {
+    const license = {
+      licenseId: "abc123",
+      validationNumber: 1,
+      validationStrings: [],
+      saltStrings: [],
+    };
+
+    const collection = {
+      findOne: jest.fn(),
+      findOneAndUpdate: jest.fn().mockResolvedValue(license),
+    };
+
+    const app = createTestApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .post("/validate-license")
+      .send({ key: "abc123" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("OK");
+    expect(response.body.validationString).toMatch(/^[a-f0-9]{64}$/);
+    expect(response.headers.deprecation).toBeUndefined();
+    expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
+      {
+        licenseId: "abc123",
+        validationNumber: { $lt: 3 },
+      },
+      expect.objectContaining({
+        $inc: { validationNumber: 1 },
+        $push: {
+          validationStrings: response.body.validationString,
+          saltStrings: expect.any(String),
+        },
+      }),
+      { returnDocument: "after" }
+    );
+    expect(collection.findOne).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    [
+      "missing",
+      {},
+      {
+        message: "License key is required",
+        code: "MISSING_LICENSE_KEY",
+      },
+    ],
+    [
+      "empty",
+      { key: "" },
+      {
+        message: "License key is required",
+        code: "MISSING_LICENSE_KEY",
+      },
+    ],
+    [
+      "whitespace only",
+      { key: "   " },
+      {
+        message: "License key is required",
+        code: "MISSING_LICENSE_KEY",
+      },
+    ],
+    [
+      "non-string",
+      { key: 123 },
+      {
+        message: "Invalid license key",
+        code: "INVALID_LICENSE_KEY",
+      },
+    ],
+  ])(
+    "POST returns structured error when license key is %s",
+    async (_, body, expectedBody) => {
+      const collection = {
+        findOne: jest.fn(),
+        findOneAndUpdate: jest.fn(),
+      };
+
+      const app = createTestApp({
+        getLicensesCollection: () => collection,
+        getMongoConnected: () => true,
+        rateLimiter: noRateLimit,
+      });
+
+      const response = await request(app).post("/validate-license").send(body);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual(expectedBody);
+      expect(collection.findOne).not.toHaveBeenCalled();
+      expect(collection.findOneAndUpdate).not.toHaveBeenCalled();
+    }
+  );
+
+  test("POST returns structured error for missing license", async () => {
+    const collection = {
+      findOneAndUpdate: jest.fn().mockResolvedValue(null),
+      findOne: jest.fn().mockResolvedValue(null),
+    };
+
+    const app = createTestApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .post("/validate-license")
+      .send({ key: "missing" });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      message: "Invalid license key",
+      code: "LICENSE_NOT_FOUND",
+    });
+  });
+
+  test("POST returns structured error when validation limit reached", async () => {
+    const license = {
+      licenseId: "abc123",
+      validationNumber: 3,
+      validationStrings: [],
+      saltStrings: [],
+    };
+
+    const collection = {
+      findOneAndUpdate: jest.fn().mockResolvedValue(null),
+      findOne: jest.fn().mockResolvedValue(license),
+    };
+
+    const app = createTestApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .post("/validate-license")
+      .send({ key: "abc123" });
+
+    expect(response.status).toBe(429);
+    expect(response.body).toEqual({
+      message: "Validation limit reached",
+      code: "VALIDATION_LIMIT_REACHED",
+    });
+  });
+
+  test("POST returns structured error when database not ready", async () => {
+    const app = createTestApp({
+      getLicensesCollection: () => null,
+      getMongoConnected: () => false,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .post("/validate-license")
+      .send({ key: "abc123" });
+
+    expect(response.status).toBe(503);
+    expect(response.body).toEqual({
+      message: "Database not ready",
+      code: "DATABASE_NOT_READY",
+    });
   });
 
   test("returns structured error for missing license", async () => {
@@ -163,7 +351,7 @@ describe("license validator service", () => {
       findOne: jest.fn().mockResolvedValue(null),
     };
 
-    const app = createApp({
+    const app = createTestApp({
       getLicensesCollection: () => collection,
       getMongoConnected: () => true,
       rateLimiter: noRateLimit,
@@ -205,7 +393,7 @@ describe("license validator service", () => {
       findOne: jest.fn().mockResolvedValue(license),
     };
 
-    const app = createApp({
+    const app = createTestApp({
       getLicensesCollection: () => collection,
       getMongoConnected: () => true,
       rateLimiter: noRateLimit,
@@ -235,7 +423,7 @@ describe("license validator service", () => {
       findOne: jest.fn().mockResolvedValue(license),
     };
 
-    const app = createApp({
+    const app = createTestApp({
       getLicensesCollection: () => collection,
       getMongoConnected: () => true,
       rateLimiter: noRateLimit,
@@ -262,7 +450,7 @@ describe("license validator service", () => {
       findOne: jest.fn(),
     };
 
-    const app = createApp({
+    const app = createTestApp({
       getLicensesCollection: () => collection,
       getMongoConnected: () => true,
       rateLimiter: noRateLimit,
@@ -283,7 +471,7 @@ describe("license validator service", () => {
   });
 
   test("returns structured error when database not ready", async () => {
-    const app = createApp({
+    const app = createTestApp({
       getLicensesCollection: () => null,
       getMongoConnected: () => false,
       rateLimiter: noRateLimit,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const cors = require("cors");
-const cryptoJs = require("crypto-js");
+const crypto = require("crypto");
 const { MongoClient } = require("mongodb");
 const rateLimit = require("express-rate-limit");
 
@@ -64,10 +64,113 @@ const getFindOneAndUpdateDocument = (result) => {
   return result;
 };
 
+const generateSalt = () => crypto.randomBytes(16).toString("hex");
+
+const generateValidationString = (licenseKey, salt, hmacSecret) =>
+  crypto
+    .createHmac("sha256", hmacSecret)
+    .update(`${licenseKey}:${salt}`)
+    .digest("hex");
+
+const validateLicenseKey = async ({ key, collection, hmacSecret }) => {
+  const { value: licenseToValidate, error: keyError } = getValidLicenseKey(key);
+
+  if (keyError) {
+    return { status: 400, body: keyError };
+  }
+
+  if (!collection) {
+    return {
+      status: 503,
+      body: {
+        message: "Database not ready",
+        code: "DATABASE_NOT_READY",
+      },
+    };
+  }
+
+  if (!hmacSecret) {
+    return {
+      status: 500,
+      body: {
+        message: "Internal Server Error",
+        code: "SERVER_CONFIGURATION_ERROR",
+      },
+    };
+  }
+
+  const salt = generateSalt();
+  const validationString = generateValidationString(
+    licenseToValidate,
+    salt,
+    hmacSecret
+  );
+
+  const updateResult = await collection.findOneAndUpdate(
+    {
+      licenseId: licenseToValidate,
+      validationNumber: { $lt: DEFAULT_VALIDATION_LIMIT },
+    },
+    {
+      $inc: { validationNumber: 1 },
+      $push: {
+        validationStrings: validationString,
+        saltStrings: salt,
+      },
+    },
+    { returnDocument: "after" }
+  );
+
+  const updatedLicense = getFindOneAndUpdateDocument(updateResult);
+
+  if (!updatedLicense) {
+    const existingLicense = await collection.findOne({
+      licenseId: licenseToValidate,
+    });
+
+    if (!existingLicense) {
+      return {
+        status: 403,
+        body: {
+          message: "Invalid license key",
+          code: "LICENSE_NOT_FOUND",
+        },
+      };
+    }
+
+    if (existingLicense.validationNumber >= DEFAULT_VALIDATION_LIMIT) {
+      return {
+        status: 429,
+        body: {
+          message: "Validation limit reached",
+          code: "VALIDATION_LIMIT_REACHED",
+        },
+      };
+    }
+
+    return {
+      status: 500,
+      body: {
+        message: "Internal Server Error",
+        code: "LICENSE_UPDATE_FAILED",
+      },
+    };
+  }
+
+  return {
+    status: 200,
+    body: {
+      message: "OK",
+      validationString: validationString,
+    },
+  };
+};
+
 const createApp = ({
   getLicensesCollection = () => licensesCollection,
   getMongoConnected = () => mongoConnected,
   rateLimiter = defaultRateLimiter,
+  hmacSecret = process.env.HMAC_SECRET,
 } = {}) => {
   const app = express();
 
@@ -84,81 +187,14 @@ const createApp = ({
 
   app.use("/validate-license", rateLimiter);
 
-  app.get("/validate-license", async (req, res) => {
-    const { value: licenseToValidate, error: keyError } = getValidLicenseKey(
-      req.query.key
-    );
-
-    if (keyError) {
-      res.status(400).json(keyError);
-      return;
-    }
-
+  const handleValidateLicense = async (key, res) => {
     try {
-      const collection = getLicensesCollection();
-      if (!collection) {
-        res.status(503).json({
-          message: "Database not ready",
-          code: "DATABASE_NOT_READY",
-        });
-        return;
-      }
-
-      const salt = cryptoJs.lib.WordArray.random(128 / 8).toString();
-      const validationString = cryptoJs
-        .HmacSHA256(licenseToValidate, salt)
-        .toString();
-
-      const updateResult = await collection.findOneAndUpdate(
-        {
-          licenseId: licenseToValidate,
-          validationNumber: { $lt: DEFAULT_VALIDATION_LIMIT },
-        },
-        {
-          $inc: { validationNumber: 1 },
-          $push: {
-            validationStrings: validationString,
-            saltStrings: salt,
-          },
-        },
-        { returnDocument: "after" }
-      );
-
-      const updatedLicense = getFindOneAndUpdateDocument(updateResult);
-
-      if (!updatedLicense) {
-        const existingLicense = await collection.findOne({
-          licenseId: licenseToValidate,
-        });
-
-        if (!existingLicense) {
-          res.status(403).json({
-            message: "Invalid license key",
-            code: "LICENSE_NOT_FOUND",
-          });
-          return;
-        }
-
-        if (existingLicense.validationNumber >= DEFAULT_VALIDATION_LIMIT) {
-          res.status(429).json({
-            message: "Validation limit reached",
-            code: "VALIDATION_LIMIT_REACHED",
-          });
-          return;
-        }
-
-        res.status(500).json({
-          message: "Internal Server Error",
-          code: "LICENSE_UPDATE_FAILED",
-        });
-        return;
-      }
-
-      // Return validationString value in the response body only after update.
-      res.status(200).json({
-        message: "OK",
-        validationString: validationString,
+      const result = await validateLicenseKey({
+        key,
+        collection: getLicensesCollection(),
+        hmacSecret,
       });
+      res.status(result.status).json(result.body);
     } catch (error) {
       console.error("Failed to read or update license in MongoDB:", error);
       res.status(500).json({
@@ -166,6 +202,19 @@ const createApp = ({
         code: "INTERNAL_SERVER_ERROR",
       });
     }
+  };
+
+  app.get("/validate-license", async (req, res) => {
+    res.set("Deprecation", "true");
+    res.set(
+      "Warning",
+      '299 - "GET /validate-license is deprecated; use POST /validate-license"'
+    );
+    await handleValidateLicense(req.query.key, res);
+  });
+
+  app.post("/validate-license", async (req, res) => {
+    await handleValidateLicense(req.body && req.body.key, res);
   });
 
   return app;
@@ -173,9 +222,15 @@ const createApp = ({
 
 const startServer = async () => {
   const url = process.env.MONGODB_URI;
+  const hmacSecret = process.env.HMAC_SECRET;
 
   if (!url) {
     console.error("Missing required environment variable MONGODB_URI.");
+    process.exit(1);
+  }
+
+  if (!hmacSecret) {
+    console.error("Missing required environment variable HMAC_SECRET.");
     process.exit(1);
   }
 
@@ -203,7 +258,7 @@ const startServer = async () => {
       }
     }
 
-    const app = createApp();
+    const app = createApp({ hmacSecret });
     app.listen(port, () => {
       console.log(`Listening on port ${port}`);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
-        "crypto-js": "^4.2.0",
         "express": "^4.18.2",
         "mongodb": "^6.3.0",
         "uuid": "^9.0.1"
@@ -154,11 +153,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "homepage": "https://github.com/jmarti/license-validator#readme",
   "dependencies": {
     "cors": "^2.8.5",
-    "crypto-js": "^4.2.0",
     "express-rate-limit": "^7.2.0",
     "express": "^4.18.2",
     "mongodb": "^6.3.0",


### PR DESCRIPTION
## Summary

- Add `POST /validate-license` as the preferred endpoint for JSON body license validation.
- Keep `GET /validate-license?key=...` working for backward compatibility and mark GET responses with deprecation headers.
- Share one validation flow between GET and POST, preserving the atomic MongoDB update behavior.
- Replace `crypto-js` usage with Node's built-in `crypto` and require a server-side `HMAC_SECRET` for validation string generation.
- Update README docs for POST usage, GET deprecation, environment variables, and examples.
- Remove the unused `crypto-js` dependency from `package.json` and `package-lock.json`.

## Validation

- `npm test` passed: 19 tests, 1 suite.
- Verified importing `index.js` works without env vars.
- Verified direct startup fails clearly when `MONGODB_URI` is missing.
- Verified direct startup fails clearly when `HMAC_SECRET` is missing.
- `git diff --check` passed.

## Notes

This PR intentionally does not change CORS, rate limiting, Vercel deployment behavior, license schema, device binding, domain binding, expiration, or revocation.