### PR TITLE
[codex] Harden HTTP deployment settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Expected document shape:
 - `MONGODB_URI`: required MongoDB connection string.
 - `HMAC_SECRET`: required server-side secret used to sign validation strings.
 - `PORT`: optional local port; defaults to `3000`.
+- `ALLOWED_ORIGINS`: optional comma-separated browser origins allowed by CORS.
+- `RATE_LIMIT_WINDOW_MS`: optional validation rate-limit window; defaults to `900000`.
+- `RATE_LIMIT_MAX`: optional validation request limit per window; defaults to `100`.
+- `TRUST_PROXY`: optional; set to `true` behind a trusted proxy or hosted platform so client IP handling works correctly.
 
 ### Health Endpoint
 
@@ -150,7 +154,28 @@ Expected document shape:
 
 ## Rate Limiting
 
-Requests to `/validate-license` are rate-limited (default: 100 requests per 15 minutes per IP).
+Requests to `POST /validate-license` and deprecated `GET /validate-license` are rate-limited. Defaults are 100 requests per 15 minutes per IP. `/health` is not rate-limited.
+
+```bash
+export RATE_LIMIT_WINDOW_MS=900000
+export RATE_LIMIT_MAX=100
+```
+
+The default in-memory limiter is best-effort in serverless environments because each instance can have separate memory. Use `TRUST_PROXY=true` when the app runs behind a trusted proxy so Express and the limiter can use the correct client IP.
+
+## CORS
+
+Browser CORS access is controlled with `ALLOWED_ORIGINS`. When it is unset, the API does not emit broad browser CORS headers, but non-browser requests such as server-to-server calls and `curl` still work.
+
+```bash
+export ALLOWED_ORIGINS="https://example.com,https://app.example.com"
+```
+
+Avoid using wildcard origins for production license validation clients. If browser access is needed, list each trusted application origin explicitly.
+
+## Deployment Notes
+
+For local development, run `npm start` with `MONGODB_URI` and `HMAC_SECRET` set. On Vercel, configure `MONGODB_URI`, `HMAC_SECRET`, `ALLOWED_ORIGINS`, and `TRUST_PROXY=true` in the project environment. CORS is handled by the Express app, not by static `vercel.json` headers, so local and deployed behavior stay consistent.
 
 ## Contributing
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,6 +1,8 @@
 const request = require("supertest");
 const crypto = require("crypto");
-const { createApp } = require("../index");
+const exportedApp = require("../index");
+
+const { createApp } = exportedApp;
 
 const noRateLimit = (req, res, next) => next();
 const TEST_HMAC_SECRET = "test-hmac-secret";
@@ -11,6 +13,11 @@ const createTestApp = (options = {}) =>
   });
 
 describe("license validator service", () => {
+  test("exports an Express app for serverless usage while keeping createApp importable", () => {
+    expect(typeof exportedApp).toBe("function");
+    expect(typeof createApp).toBe("function");
+  });
+
   test("health reports MongoDB readiness", async () => {
     const app = createTestApp({
       getMongoConnected: () => false,
@@ -21,6 +28,73 @@ describe("license validator service", () => {
 
     expect(response.status).toBe(503);
     expect(response.body).toEqual({ status: "ok", mongoConnected: false });
+  });
+
+  test("health is not rate limited", async () => {
+    const app = createTestApp({
+      getMongoConnected: () => true,
+      rateLimitOptions: { windowMs: 60 * 1000, limit: 1 },
+    });
+
+    const firstResponse = await request(app).get("/health");
+    const secondResponse = await request(app).get("/health");
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+  });
+
+  test("allows configured CORS origins", async () => {
+    const app = createTestApp({
+      allowedOrigins: ["https://app.example.com"],
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .get("/health")
+      .set("Origin", "https://app.example.com");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["access-control-allow-origin"]).toBe(
+      "https://app.example.com"
+    );
+  });
+
+  test("does not emit permissive CORS headers for disallowed origins", async () => {
+    const app = createTestApp({
+      allowedOrigins: ["https://app.example.com"],
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .get("/health")
+      .set("Origin", "https://evil.example.com");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  test("requests without Origin still work", async () => {
+    const app = createTestApp({
+      allowedOrigins: ["https://app.example.com"],
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app).get("/health");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  test("trust proxy can be enabled through app config", () => {
+    const app = createTestApp({
+      trustProxy: true,
+      rateLimiter: noRateLimit,
+    });
+
+    expect(app.get("trust proxy")).toBe(1);
   });
 
   test("returns structured error when license key is missing", async () => {
@@ -216,6 +290,68 @@ describe("license validator service", () => {
       { returnDocument: "after" }
     );
     expect(collection.findOne).not.toHaveBeenCalled();
+  });
+
+  test("POST /validate-license is rate limited with configurable limits", async () => {
+    const license = {
+      licenseId: "abc123",
+      validationNumber: 1,
+      validationStrings: [],
+      saltStrings: [],
+    };
+
+    const collection = {
+      findOne: jest.fn(),
+      findOneAndUpdate: jest.fn().mockResolvedValue(license),
+    };
+
+    const app = createTestApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimitOptions: { windowMs: 60 * 1000, limit: 1 },
+    });
+
+    const firstResponse = await request(app)
+      .post("/validate-license")
+      .send({ key: "abc123" });
+    const secondResponse = await request(app)
+      .post("/validate-license")
+      .send({ key: "abc123" });
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(429);
+    expect(collection.findOneAndUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test("GET /validate-license is rate limited with configurable limits", async () => {
+    const license = {
+      licenseId: "abc123",
+      validationNumber: 1,
+      validationStrings: [],
+      saltStrings: [],
+    };
+
+    const collection = {
+      findOne: jest.fn(),
+      findOneAndUpdate: jest.fn().mockResolvedValue(license),
+    };
+
+    const app = createTestApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimitOptions: { windowMs: 60 * 1000, limit: 1 },
+    });
+
+    const firstResponse = await request(app)
+      .get("/validate-license")
+      .query({ key: "abc123" });
+    const secondResponse = await request(app)
+      .get("/validate-license")
+      .query({ key: "abc123" });
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(429);
+    expect(collection.findOneAndUpdate).toHaveBeenCalledTimes(1);
   });
 
   test.each([

--- a/index.js
+++ b/index.js
@@ -12,12 +12,52 @@ let mongoConnected = false;
 const maxConnectAttempts = 5;
 const connectRetryDelayMs = 1000;
 const DEFAULT_VALIDATION_LIMIT = 3;
+const DEFAULT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+const DEFAULT_RATE_LIMIT_MAX = 100;
 
-const defaultRateLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 100,
-  standardHeaders: true,
-  legacyHeaders: false,
+const parseAllowedOrigins = (value) => {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+};
+
+const getPositiveInteger = (value, fallback) => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const getBoolean = (value) => value === true || value === "true";
+
+const createValidationRateLimiter = ({
+  windowMs = getPositiveInteger(
+    process.env.RATE_LIMIT_WINDOW_MS,
+    DEFAULT_RATE_LIMIT_WINDOW_MS
+  ),
+  limit = getPositiveInteger(process.env.RATE_LIMIT_MAX, DEFAULT_RATE_LIMIT_MAX),
+} = {}) =>
+  rateLimit({
+    windowMs,
+    limit,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
+const createCorsOptions = (
+  allowedOrigins = parseAllowedOrigins(process.env.ALLOWED_ORIGINS)
+) => ({
+  origin: (origin, callback) => {
+    if (!origin) {
+      callback(null, false);
+      return;
+    }
+
+    callback(null, allowedOrigins.includes(origin) ? origin : false);
+  },
 });
 
 const getValidLicenseKey = (key) => {
@@ -166,15 +206,50 @@ const validateLicenseKey = async ({ key, collection, hmacSecret }) => {
   };
 };
 
+const createMongoCollectionProvider = (url) => {
+  let clientPromise;
+  let collection;
+
+  return async () => {
+    if (collection) {
+      return collection;
+    }
+
+    if (!url) {
+      return null;
+    }
+
+    if (!clientPromise) {
+      const client = new MongoClient(url);
+      clientPromise = client.connect().then((connectedClient) => {
+        mongoConnected = true;
+        return connectedClient;
+      });
+    }
+
+    const client = await clientPromise;
+    const db = client.db(dbName);
+    collection = db.collection("licenses");
+    return collection;
+  };
+};
+
 const createApp = ({
   getLicensesCollection = () => licensesCollection,
   getMongoConnected = () => mongoConnected,
-  rateLimiter = defaultRateLimiter,
+  rateLimiter,
+  rateLimitOptions,
   hmacSecret = process.env.HMAC_SECRET,
+  allowedOrigins = parseAllowedOrigins(process.env.ALLOWED_ORIGINS),
+  trustProxy = getBoolean(process.env.TRUST_PROXY),
 } = {}) => {
   const app = express();
 
-  app.use(cors());
+  if (trustProxy) {
+    app.set("trust proxy", 1);
+  }
+
+  app.use(cors(createCorsOptions(allowedOrigins)));
 
   // Enable JSON support
   app.use(express.json());
@@ -185,13 +260,16 @@ const createApp = ({
     res.status(statusCode).json({ status: "ok", mongoConnected: connected });
   });
 
-  app.use("/validate-license", rateLimiter);
+  app.use(
+    "/validate-license",
+    rateLimiter || createValidationRateLimiter(rateLimitOptions)
+  );
 
   const handleValidateLicense = async (key, res) => {
     try {
       const result = await validateLicenseKey({
         key,
-        collection: getLicensesCollection(),
+        collection: await getLicensesCollection(),
         hmacSecret,
       });
       res.status(result.status).json(result.body);
@@ -272,13 +350,17 @@ if (require.main === module) {
   startServer();
 }
 
-module.exports = {
-  createApp,
-  startServer,
-  setLicensesCollection: (collection) => {
-    licensesCollection = collection;
-  },
-  setMongoConnected: (connected) => {
-    mongoConnected = connected;
-  },
+const serverlessApp = createApp({
+  getLicensesCollection: createMongoCollectionProvider(process.env.MONGODB_URI),
+  hmacSecret: process.env.HMAC_SECRET,
+});
+
+module.exports = serverlessApp;
+module.exports.createApp = createApp;
+module.exports.startServer = startServer;
+module.exports.setLicensesCollection = (collection) => {
+  licensesCollection = collection;
+};
+module.exports.setMongoConnected = (connected) => {
+  mongoConnected = connected;
 };

--- a/vercel.json
+++ b/vercel.json
@@ -6,31 +6,6 @@
             "use": "@vercel/node"
         }
     ],
-    "headers":
-    [
-        {
-            "headers":
-            [
-                {
-                    "key": "Access-Control-Allow-Credentials",
-                    "value": "true"
-                },
-                {
-                    "key": "Access-Control-Allow-Origin",
-                    "value": "*"
-                },
-                {
-                    "key": "Access-Control-Allow-Methods",
-                    "value": "GET,OPTIONS,PATCH,DELETE,POST,PUT"
-                },
-                {
-                    "key": "Access-Control-Allow-Headers",
-                    "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
-                }
-            ],
-            "source": "/api/(.*)"
-        }
-    ],
     "rewrites":
     [
         {


### PR DESCRIPTION
## Summary

- Add configurable CORS with `ALLOWED_ORIGINS` and remove broad default browser CORS behavior.
- Make validation endpoint rate limits configurable with `RATE_LIMIT_WINDOW_MS` and `RATE_LIMIT_MAX` while preserving the default 100 requests per 15 minutes.
- Add `TRUST_PROXY=true` support for hosted/proxy deployments.
- Keep rate limiting scoped to `GET /validate-license` and `POST /validate-license`; `/health` is not rate-limited.
- Export the Express app for Vercel/serverless import without calling `app.listen()` on import.
- Remove conflicting wildcard CORS headers from `vercel.json` so app-level CORS is authoritative.
- Update README deployment, CORS, proxy, and rate-limit notes.

## Validation

- `npm test` passed: 27 tests, 1 suite.
- `node -c index.js` passed.
- `vercel.json` parses as JSON.
- Verified importing `index.js` without env vars works.
- Verified direct startup still fails clearly without `MONGODB_URI`.
- Verified direct startup still fails clearly without `HMAC_SECRET`.
- `git diff --check` passed.

## Notes

This PR intentionally does not change license validation business logic, validation string generation, CORS policy beyond configurability, or the MongoDB schema. The in-memory rate limiter remains best-effort in serverless environments; an external store can be considered later if strict global limits are required.