### PR TITLE
[codex] Audit release readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Deprecated but temporarily supported for backward compatibility. GET responses i
 - `429`: validation limit reached, `{"message":"Validation limit reached","code":"VALIDATION_LIMIT_REACHED"}`.
 - `429`: request rate limit reached, returned by `express-rate-limit`.
 - `503`: database not ready, `{"message":"Database not ready","code":"DATABASE_NOT_READY"}`.
-- `500`: unexpected validation/update failure, such as `{"message":"Internal Server Error","code":"INTERNAL_SERVER_ERROR"}` or `{"message":"Internal Server Error","code":"LICENSE_UPDATE_FAILED"}`.
+- `500`: malformed license document, `{"message":"License validation failed","code":"LICENSE_DOCUMENT_INVALID"}`.
+- `500`: unexpected validation/update/configuration failure, such as `{"message":"Internal Server Error","code":"INTERNAL_SERVER_ERROR"}`, `{"message":"Internal Server Error","code":"LICENSE_UPDATE_FAILED"}`, or `{"message":"Internal Server Error","code":"SERVER_CONFIGURATION_ERROR"}`.
 
 ## Environment Variables
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -233,6 +233,9 @@ describe("license validator service", () => {
     expect(response.body.message).toBe("OK");
     expect(response.body.validationString).toBeTruthy();
     expect(response.headers.deprecation).toBe("true");
+    expect(response.headers.warning).toBe(
+      '299 - "GET /validate-license is deprecated; use POST /validate-license"'
+    );
     expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
       atomicValidationFilter("abc123"),
       {
@@ -295,6 +298,32 @@ describe("license validator service", () => {
       { returnDocument: "after" }
     );
     expect(collection.findOne).toHaveBeenCalledWith({ licenseId: "abc123" });
+  });
+
+  test("POST returns structured error when HMAC secret is not configured", async () => {
+    const collection = {
+      findOne: jest.fn(),
+      findOneAndUpdate: jest.fn(),
+    };
+
+    const app = createApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      hmacSecret: "",
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .post("/validate-license")
+      .send({ key: "abc123" });
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      message: "Internal Server Error",
+      code: "SERVER_CONFIGURATION_ERROR",
+    });
+    expect(collection.findOne).not.toHaveBeenCalled();
+    expect(collection.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
   test.each([


### PR DESCRIPTION
## Summary
- Document controlled 500 response codes for malformed license documents and missing server configuration.
- Add coverage that deprecated GET responses include the Warning header.
- Add coverage that missing HMAC configuration fails before MongoDB access.

## Validation
- `node -c index.js`
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('vercel.json', 'utf8'))"`
- `npm ls --depth=0`
- `npm test` (36 tests passing)

## Notes
- No product behavior changes intended; this is a release-readiness cleanup PR.