### PR TITLE
[codex] Fix Vercel trust proxy default

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Deprecated but temporarily supported for backward compatibility. GET responses i
 | `ALLOWED_ORIGINS` | No | No browser CORS origins | `https://example.com,https://app.example.com` | Comma-separated browser origins allowed by CORS. |
 | `RATE_LIMIT_WINDOW_MS` | No | `900000` | `900000` | Validation rate-limit window. |
 | `RATE_LIMIT_MAX` | No | `100` | `100` | Validation requests allowed per window per IP. |
-| `TRUST_PROXY` | No | unset/false | `true` | Enables `app.set("trust proxy", 1)` behind trusted proxies. |
+| `TRUST_PROXY` | No | auto-enabled on Vercel; otherwise unset/false | `true` | Enables `app.set("trust proxy", 1)` behind trusted proxies. |
+| `VERCEL` | Set by Vercel | unset | `1` | Platform marker used to enable trusted proxy handling on Vercel. |
 | `NODE_ENV` | No | unset | `production` | Standard Node environment label; current CORS behavior is controlled by `ALLOWED_ORIGINS`. |
 
 ## MongoDB Setup
@@ -111,7 +112,7 @@ The app supports local long-running server mode with `npm start` and Vercel/serv
 
 CORS is handled by the Express app. Set `ALLOWED_ORIGINS` in production instead of using wildcard static headers. Requests without an `Origin` header still work for server-to-server clients and `curl`.
 
-Rate limiting applies to `POST /validate-license` and deprecated `GET /validate-license`; `/health` is not rate-limited. The default in-memory limiter is best-effort in serverless environments because each instance has separate memory. Use `TRUST_PROXY=true` on trusted hosted/proxy platforms so client IP handling works correctly.
+Rate limiting applies to `POST /validate-license` and deprecated `GET /validate-license`; `/health` is not rate-limited. The default in-memory limiter is best-effort in serverless environments because each instance has separate memory. Trusted proxy handling is enabled automatically on Vercel. Use `TRUST_PROXY=true` on other trusted hosted/proxy platforms so client IP handling works correctly.
 
 ## Security Notes
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -108,6 +108,37 @@ describe("license validator service", () => {
     expect(app.get("trust proxy")).toBe(1);
   });
 
+  test("trust proxy is enabled automatically on Vercel", async () => {
+    const originalVercel = process.env.VERCEL;
+    process.env.VERCEL = "1";
+
+    try {
+      const app = createTestApp({
+        getMongoConnected: () => true,
+        rateLimitOptions: { windowMs: 60 * 1000, limit: 10 },
+      });
+
+      expect(app.get("trust proxy")).toBe(1);
+
+      const response = await request(app)
+        .post("/validate-license")
+        .set("X-Forwarded-For", "203.0.113.10")
+        .send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        message: "License key is required",
+        code: "MISSING_LICENSE_KEY",
+      });
+    } finally {
+      if (originalVercel === undefined) {
+        delete process.env.VERCEL;
+      } else {
+        process.env.VERCEL = originalVercel;
+      }
+    }
+  });
+
   test("returns structured error when license key is missing", async () => {
     const collection = {
       findOne: jest.fn(),

--- a/index.js
+++ b/index.js
@@ -33,6 +33,12 @@ const getPositiveInteger = (value, fallback) => {
 
 const getBoolean = (value) => value === true || value === "true";
 
+const isVercelEnvironment = (value = process.env.VERCEL) =>
+  value === "1" || getBoolean(value);
+
+const shouldTrustProxy = () =>
+  getBoolean(process.env.TRUST_PROXY) || isVercelEnvironment();
+
 const createValidationRateLimiter = ({
   windowMs = getPositiveInteger(
     process.env.RATE_LIMIT_WINDOW_MS,
@@ -314,7 +320,7 @@ const createApp = ({
   rateLimitOptions,
   hmacSecret = process.env.HMAC_SECRET,
   allowedOrigins = parseAllowedOrigins(process.env.ALLOWED_ORIGINS),
-  trustProxy = getBoolean(process.env.TRUST_PROXY),
+  trustProxy = shouldTrustProxy(),
 } = {}) => {
   const app = express();
 


### PR DESCRIPTION
## Summary
- Auto-enable Express `trust proxy` when running on Vercel via the platform-provided `VERCEL=1` marker.
- Add a regression test for `X-Forwarded-For` requests through the real validation rate limiter.
- Update README deployment notes to document the Vercel default and `TRUST_PROXY=true` for other proxy platforms.

## Why
Vercel sets `X-Forwarded-For` on incoming requests. `express-rate-limit` throws `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` when that header is present and Express `trust proxy` is disabled.

## Validation
- `node -c index.js`
- `git diff --check`
- `npm test` (37 tests passing)