### PR TITLE
[codex] Add license activation records

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 
-This is a small Node.js/Express license validation API. The main application lives in `index.js`, exports an Express app for serverless use, and exposes `createApp` for tests. Tests are in `__tests__/app.test.js` and use Jest with Supertest. `vercel.json` contains Vercel routing only; CORS is handled in the app. `licenses.json` is fake sample data and is not read at runtime.
+This is a small Node.js/Express license activation and validation API. The main application lives in `index.js`, exports an Express app for serverless use, and exposes `createApp` for tests. Tests are in `__tests__/app.test.js` and use Jest with Supertest. `vercel.json` contains Vercel routing only; CORS is handled in the app. `licenses.json` is fake sample data and is not read at runtime.
 
 ## Build, Test, and Development Commands
 
@@ -20,9 +20,11 @@ npm start
 
 ## API And Runtime Notes
 
-Use `POST /validate-license` with JSON body `{ "key": "..." }` for new clients. `GET /validate-license?key=...` is deprecated but kept for backward compatibility. `GET /health` reports MongoDB readiness.
+Use `POST /activate-license` with JSON body `{ "key": "...", "deviceId": "...", "pluginVersion": "..." }` for new Photoshop plugin code. Keep `POST /validate-license` for backward compatibility. `GET /validate-license?key=...` is deprecated but must not be removed without explicit approval. `GET /health` reports MongoDB readiness.
 
 License validation must stay atomic: enforce the validation limit in MongoDB with `findOneAndUpdate`, `$inc`, and `$push`. Do not reintroduce read-then-write validation count logic. Legacy license documents may omit `validationNumber`, `validationStrings`, or `saltStrings`; existing values for those fields must have the expected number/array types and malformed documents should fail with a controlled server error.
+
+Activation logic must also stay atomic. Same-device reactivation must reuse the existing activation and must not consume another slot. New-device activation must only append an activation record when the license is active and the current activation count is below `maxActivations`. Legacy activation records may omit `status`, `maxActivations`, or `activations`; existing values must have the documented types and malformed documents should fail safely.
 
 ## Coding Style & Naming Conventions
 
@@ -38,4 +40,4 @@ Keep commits focused and imperative, such as `Add POST license validation`. Pull
 
 ## Security & Configuration Tips
 
-Do not commit secrets, real MongoDB credentials, or production license data. Required runtime env vars are `MONGODB_URI` and `HMAC_SECRET`; optional HTTP/deployment vars include `ALLOWED_ORIGINS`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `TRUST_PROXY`, `PORT`, and `NODE_ENV`. Restrict browser origins in production and treat in-memory rate limiting as best-effort in serverless environments.
+Do not commit secrets, real MongoDB credentials, or production license data. Required runtime env vars are `MONGODB_URI` and `HMAC_SECRET`; optional HTTP/deployment vars include `ALLOWED_ORIGINS`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `TRUST_PROXY`, `PORT`, and `NODE_ENV`. Restrict browser origins in production and treat in-memory rate limiting as best-effort in serverless environments. Never put backend secrets in Photoshop plugin code; device IDs should be stable opaque hashes rather than sensitive raw personal data.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # License Validator Service
 
-Node.js/Express API for validating software license keys stored in MongoDB. Runtime validation uses the `licenseDatabase.licenses` collection; `licenses.json` is sample data only and is not read by the application.
+Node.js/Express API for activating and validating software license keys stored in MongoDB. Runtime license checks use the `licenseDatabase.licenses` collection; `licenses.json` is sample data only and is not read by the application.
 
 ## Endpoints
 
@@ -19,9 +19,32 @@ Success:
 
 When MongoDB is not ready, the endpoint returns `503` with `mongoConnected: false`.
 
+### `POST /activate-license`
+
+Preferred endpoint for the Photoshop plugin. Use activation when a device/install claims a license slot. Repeated activation from the same `deviceId` reuses the existing activation and does not consume another slot.
+
+```bash
+curl -X POST http://localhost:3000/activate-license \
+  -H "Content-Type: application/json" \
+  -d '{"key":"example-license-key","deviceId":"stable-device-hash","pluginVersion":"1.0.0"}'
+```
+
+Success:
+
+```json
+{
+  "message": "OK",
+  "activationId": "act_...",
+  "activationToken": "<hash>",
+  "activated": true
+}
+```
+
+Existing device success also includes `"reused": true`.
+
 ### `POST /validate-license`
 
-Preferred endpoint for license validation. New clients should use POST so license keys are not placed in URLs, browser history, logs, proxies, analytics, CDNs, or referrers.
+Backward-compatible validation endpoint. New Photoshop plugin code should use `POST /activate-license`; this endpoint remains available for older clients that only send a license key.
 
 ```bash
 curl -X POST http://localhost:3000/validate-license \
@@ -40,13 +63,16 @@ Success:
 
 ### `GET /validate-license?key=<licenseId>`
 
-Deprecated but temporarily supported for backward compatibility. GET responses include deprecation headers. Prefer `POST /validate-license` for all new integrations.
+Deprecated but temporarily supported for backward compatibility. GET responses include deprecation headers. Do not send license keys in URLs for new integrations.
 
 ## Error Responses
 
 - `400`: missing or invalid key, for example `{"message":"License key is required","code":"MISSING_LICENSE_KEY"}` or `{"message":"Invalid license key","code":"INVALID_LICENSE_KEY"}`.
+- `400`: missing or invalid activation metadata, such as `{"message":"Device ID is required","code":"MISSING_DEVICE_ID"}` or `{"message":"Invalid plugin version","code":"INVALID_PLUGIN_VERSION"}`.
 - `403`: unknown license, `{"message":"Invalid license key","code":"LICENSE_NOT_FOUND"}`.
+- `403`: inactive license, `{"message":"License is not active","code":"LICENSE_NOT_ACTIVE"}`.
 - `429`: validation limit reached, `{"message":"Validation limit reached","code":"VALIDATION_LIMIT_REACHED"}`.
+- `429`: activation limit reached, `{"message":"No more activations","code":"ACTIVATION_LIMIT_REACHED"}`.
 - `429`: request rate limit reached, returned by `express-rate-limit`.
 - `503`: database not ready, `{"message":"Database not ready","code":"DATABASE_NOT_READY"}`.
 - `500`: malformed license document, `{"message":"License validation failed","code":"LICENSE_DOCUMENT_INVALID"}`.
@@ -76,7 +102,29 @@ Create a unique index so each key maps to one document:
 db.licenses.createIndex({ licenseId: 1 }, { unique: true })
 ```
 
-Expected document shape:
+Recommended activation document shape:
+
+```js
+{
+  licenseId: "example-license-key",
+  status: "active",
+  maxActivations: 3,
+  activations: [
+    {
+      activationId: "act_...",
+      deviceId: "stable-device-hash",
+      activationToken: "hash",
+      pluginVersion: "1.0.0",
+      activatedAt: "2026-06-14T00:00:00.000Z",
+      lastSeenAt: "2026-06-14T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+For activation records, missing `status` is treated as `"active"`, missing `maxActivations` is treated as `3`, and missing `activations` is treated as an empty array. If present, `status` must be `active`, `revoked`, or `disabled`; only `active` licenses can activate. `maxActivations` must be a non-negative integer and `activations` must be an array of valid activation objects.
+
+Legacy validation fields are still supported for backward-compatible validation endpoints:
 
 ```js
 {
@@ -88,6 +136,12 @@ Expected document shape:
 ```
 
 For legacy records, `validationNumber`, `validationStrings`, and `saltStrings` may be omitted; validation treats an omitted `validationNumber` as `0` and creates omitted arrays when the license is validated. If those fields exist, they must have the expected types: `validationNumber` must be a non-negative integer, and `validationStrings` and `saltStrings` must be arrays of strings. License validation increments `validationNumber` atomically with MongoDB and stores generated validation strings and salts in the arrays.
+
+## Terminology
+
+- Activation: a Photoshop plugin device/install claims one license slot with `key`, `deviceId`, and optional `pluginVersion`.
+- Validation: older compatibility flow that accepts only a license key.
+- Activation token: a server-generated activation receipt the plugin can store locally; it is not a complete DRM system by itself.
 
 ## Local Development
 
@@ -112,12 +166,15 @@ The app supports local long-running server mode with `npm start` and Vercel/serv
 
 CORS is handled by the Express app. Set `ALLOWED_ORIGINS` in production instead of using wildcard static headers. Requests without an `Origin` header still work for server-to-server clients and `curl`.
 
-Rate limiting applies to `POST /validate-license` and deprecated `GET /validate-license`; `/health` is not rate-limited. The default in-memory limiter is best-effort in serverless environments because each instance has separate memory. Trusted proxy handling is enabled automatically on Vercel. Use `TRUST_PROXY=true` on other trusted hosted/proxy platforms so client IP handling works correctly.
+Rate limiting applies to `POST /activate-license`, `POST /validate-license`, and deprecated `GET /validate-license`; `/health` is not rate-limited. The default in-memory limiter is best-effort in serverless environments because each instance has separate memory. Trusted proxy handling is enabled automatically on Vercel. Use `TRUST_PROXY=true` on other trusted hosted/proxy platforms so client IP handling works correctly.
 
 ## Security Notes
 
-- Prefer POST; do not send license keys in URLs for new clients.
-- Keep `HMAC_SECRET` private and rotate it carefully because it signs validation strings.
+- Prefer `POST /activate-license` for the Photoshop plugin; do not send license keys in URLs for new clients.
+- Keep `HMAC_SECRET` private and rotate it carefully because it signs validation strings and activation tokens.
+- The plugin must not contain `HMAC_SECRET`.
+- Send a stable hashed `deviceId`, not sensitive raw personal data.
+- Treat activation tokens as activation receipts; add server-side check/revocation endpoints later if the plugin needs ongoing license enforcement.
 - Do not commit production MongoDB credentials, HMAC secrets, or production license data.
 - Restrict `ALLOWED_ORIGINS` to trusted browser clients in production.
 - Treat in-memory rate limiting as best-effort in serverless deployments.

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -22,6 +22,32 @@ const invalidDocumentBody = {
   message: "License validation failed",
   code: "LICENSE_DOCUMENT_INVALID",
 };
+const activeLicenseFilter = (licenseId) => ({
+  licenseId,
+  $or: [{ status: "active" }, { status: { $exists: false } }],
+});
+const existingActivationFilter = (licenseId, deviceId) => ({
+  ...activeLicenseFilter(licenseId),
+  activations: { $elemMatch: { deviceId } },
+});
+const newActivationFilter = (licenseId, deviceId) => ({
+  ...activeLicenseFilter(licenseId),
+  $nor: [{ activations: { $elemMatch: { deviceId } } }],
+  $expr: {
+    $lt: [
+      { $size: { $ifNull: ["$activations", []] } },
+      { $ifNull: ["$maxActivations", 3] },
+    ],
+  },
+});
+const existingActivation = {
+  activationId: "act_existing",
+  deviceId: "device-1",
+  activationToken: "existing-token",
+  pluginVersion: "1.0.0",
+  activatedAt: "2026-06-14T00:00:00.000Z",
+  lastSeenAt: "2026-06-14T00:00:00.000Z",
+};
 
 describe("license validator service", () => {
   test("exports an Express app for serverless usage while keeping createApp importable", () => {
@@ -137,6 +163,439 @@ describe("license validator service", () => {
         process.env.VERCEL = originalVercel;
       }
     }
+  });
+
+  test.each([
+    [
+      "missing key",
+      { deviceId: "device-1" },
+      {
+        message: "License key is required",
+        code: "MISSING_LICENSE_KEY",
+      },
+    ],
+    [
+      "empty key",
+      { key: "", deviceId: "device-1" },
+      {
+        message: "License key is required",
+        code: "MISSING_LICENSE_KEY",
+      },
+    ],
+    [
+      "whitespace key",
+      { key: "   ", deviceId: "device-1" },
+      {
+        message: "License key is required",
+        code: "MISSING_LICENSE_KEY",
+      },
+    ],
+    [
+      "non-string key",
+      { key: 123, deviceId: "device-1" },
+      {
+        message: "Invalid license key",
+        code: "INVALID_LICENSE_KEY",
+      },
+    ],
+    [
+      "missing deviceId",
+      { key: "abc123" },
+      {
+        message: "Device ID is required",
+        code: "MISSING_DEVICE_ID",
+      },
+    ],
+    [
+      "empty deviceId",
+      { key: "abc123", deviceId: "" },
+      {
+        message: "Device ID is required",
+        code: "MISSING_DEVICE_ID",
+      },
+    ],
+    [
+      "whitespace deviceId",
+      { key: "abc123", deviceId: "   " },
+      {
+        message: "Device ID is required",
+        code: "MISSING_DEVICE_ID",
+      },
+    ],
+    [
+      "non-string deviceId",
+      { key: "abc123", deviceId: 123 },
+      {
+        message: "Invalid device ID",
+        code: "INVALID_DEVICE_ID",
+      },
+    ],
+    [
+      "non-string pluginVersion",
+      { key: "abc123", deviceId: "device-1", pluginVersion: 123 },
+      {
+        message: "Invalid plugin version",
+        code: "INVALID_PLUGIN_VERSION",
+      },
+    ],
+  ])("POST /activate-license returns 400 for %s", async (_, body, expected) => {
+    const collection = {
+      findOne: jest.fn(),
+      findOneAndUpdate: jest.fn(),
+    };
+
+    const app = createTestApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app).post("/activate-license").send(body);
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual(expected);
+    expect(collection.findOne).not.toHaveBeenCalled();
+    expect(collection.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test("POST /activate-license creates a new activation atomically", async () => {
+    const license = {
+      licenseId: "abc123",
+      status: "active",
+      maxActivations: 3,
+      activations: [],
+    };
+
+    const collection = {
+      findOne: jest.fn().mockResolvedValue(license),
+      findOneAndUpdate: jest
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockImplementationOnce((filter, update) =>
+          Promise.resolve({
+            ...license,
+            activations: [update.$push.activations],
+          })
+        ),
+    };
+
+    const app = createTestApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .post("/activate-license")
+      .send({
+        key: "abc123",
+        deviceId: "device-1",
+        pluginVersion: "1.0.0",
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "OK",
+      activationId: expect.stringMatching(/^act_[a-f0-9]{24}$/),
+      activationToken: expect.stringMatching(/^[a-f0-9]{64}$/),
+      activated: true,
+    });
+    expect(collection.findOne).toHaveBeenCalledWith({ licenseId: "abc123" });
+    expect(collection.findOneAndUpdate).toHaveBeenNthCalledWith(
+      1,
+      existingActivationFilter("abc123", "device-1"),
+      {
+        $set: {
+          "activations.$.lastSeenAt": expect.any(String),
+          "activations.$.pluginVersion": "1.0.0",
+        },
+      },
+      { returnDocument: "after" }
+    );
+    expect(collection.findOneAndUpdate).toHaveBeenNthCalledWith(
+      2,
+      newActivationFilter("abc123", "device-1"),
+      {
+        $push: {
+          activations: {
+            activationId: response.body.activationId,
+            deviceId: "device-1",
+            activationToken: response.body.activationToken,
+            pluginVersion: "1.0.0",
+            activatedAt: expect.any(String),
+            lastSeenAt: expect.any(String),
+          },
+        },
+      },
+      { returnDocument: "after" }
+    );
+  });
+
+  test("POST /activate-license supports legacy license defaults", async () => {
+    const legacyLicense = { licenseId: "legacy-key" };
+    const collection = {
+      findOne: jest.fn().mockResolvedValue(legacyLicense),
+      findOneAndUpdate: jest
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockImplementationOnce((filter, update) =>
+          Promise.resolve({
+            ...legacyLicense,
+            activations: [update.$push.activations],
+          })
+        ),
+    };
+
+    const app = createTestApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .post("/activate-license")
+      .send({ key: "legacy-key", deviceId: "device-1" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.activated).toBe(true);
+    expect(collection.findOneAndUpdate).toHaveBeenNthCalledWith(
+      2,
+      newActivationFilter("legacy-key", "device-1"),
+      expect.objectContaining({
+        $push: {
+          activations: expect.objectContaining({
+            deviceId: "device-1",
+          }),
+        },
+      }),
+      { returnDocument: "after" }
+    );
+  });
+
+  test("POST /activate-license reuses an existing device activation", async () => {
+    const license = {
+      licenseId: "abc123",
+      status: "active",
+      maxActivations: 1,
+      activations: [existingActivation],
+    };
+    const updatedLicense = {
+      ...license,
+      activations: [
+        {
+          ...existingActivation,
+          pluginVersion: "1.1.0",
+          lastSeenAt: "2026-06-14T01:00:00.000Z",
+        },
+      ],
+    };
+    const collection = {
+      findOne: jest.fn().mockResolvedValue(license),
+      findOneAndUpdate: jest.fn().mockResolvedValueOnce(updatedLicense),
+    };
+
+    const app = createTestApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .post("/activate-license")
+      .send({
+        key: "abc123",
+        deviceId: "device-1",
+        pluginVersion: "1.1.0",
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      message: "OK",
+      activationId: "act_existing",
+      activationToken: "existing-token",
+      activated: true,
+      reused: true,
+    });
+    expect(collection.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    expect(collection.findOneAndUpdate).toHaveBeenCalledWith(
+      existingActivationFilter("abc123", "device-1"),
+      {
+        $set: {
+          "activations.$.lastSeenAt": expect.any(String),
+          "activations.$.pluginVersion": "1.1.0",
+        },
+      },
+      { returnDocument: "after" }
+    );
+  });
+
+  test("POST /activate-license returns 429 when activation slots are full", async () => {
+    const license = {
+      licenseId: "abc123",
+      status: "active",
+      maxActivations: 1,
+      activations: [existingActivation],
+    };
+    const collection = {
+      findOne: jest
+        .fn()
+        .mockResolvedValueOnce(license)
+        .mockResolvedValueOnce(license),
+      findOneAndUpdate: jest.fn().mockResolvedValue(null),
+    };
+
+    const app = createTestApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .post("/activate-license")
+      .send({ key: "abc123", deviceId: "device-2" });
+
+    expect(response.status).toBe(429);
+    expect(response.body).toEqual({
+      message: "No more activations",
+      code: "ACTIVATION_LIMIT_REACHED",
+    });
+    expect(collection.findOneAndUpdate).toHaveBeenNthCalledWith(
+      2,
+      newActivationFilter("abc123", "device-2"),
+      expect.objectContaining({ $push: { activations: expect.any(Object) } }),
+      { returnDocument: "after" }
+    );
+  });
+
+  test.each(["revoked", "disabled"])(
+    "POST /activate-license rejects %s licenses",
+    async (status) => {
+      const collection = {
+        findOne: jest.fn().mockResolvedValue({
+          licenseId: "abc123",
+          status,
+          activations: [],
+        }),
+        findOneAndUpdate: jest.fn(),
+      };
+
+      const app = createTestApp({
+        getLicensesCollection: () => collection,
+        getMongoConnected: () => true,
+        rateLimiter: noRateLimit,
+      });
+
+      const response = await request(app)
+        .post("/activate-license")
+        .send({ key: "abc123", deviceId: "device-1" });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toEqual({
+        message: "License is not active",
+        code: "LICENSE_NOT_ACTIVE",
+      });
+      expect(collection.findOneAndUpdate).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each([
+    ["invalid status", { status: "pending", activations: [] }],
+    ["non-number maxActivations", { maxActivations: "three", activations: [] }],
+    ["negative maxActivations", { maxActivations: -1, activations: [] }],
+    ["non-array activations", { activations: "not-an-array" }],
+    [
+      "malformed activation entry",
+      {
+        activations: [
+          {
+            activationId: "act_bad",
+            deviceId: "",
+            activationToken: "token",
+          },
+        ],
+      },
+    ],
+  ])("POST /activate-license returns controlled error for %s", async (_, fields) => {
+    const collection = {
+      findOne: jest.fn().mockResolvedValue({
+        licenseId: "bad-key",
+        ...fields,
+      }),
+      findOneAndUpdate: jest.fn(),
+    };
+
+    const app = createTestApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .post("/activate-license")
+      .send({ key: "bad-key", deviceId: "device-1" });
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual(invalidDocumentBody);
+    expect(collection.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test("POST /activate-license returns 403 for unknown licenses", async () => {
+    const collection = {
+      findOne: jest.fn().mockResolvedValue(null),
+      findOneAndUpdate: jest.fn(),
+    };
+
+    const app = createTestApp({
+      getLicensesCollection: () => collection,
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .post("/activate-license")
+      .send({ key: "missing", deviceId: "device-1" });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      message: "Invalid license key",
+      code: "LICENSE_NOT_FOUND",
+    });
+    expect(collection.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test("POST /activate-license returns 503 when database is not ready", async () => {
+    const app = createTestApp({
+      getLicensesCollection: () => null,
+      getMongoConnected: () => false,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .post("/activate-license")
+      .send({ key: "abc123", deviceId: "device-1" });
+
+    expect(response.status).toBe(503);
+    expect(response.body).toEqual({
+      message: "Database not ready",
+      code: "DATABASE_NOT_READY",
+    });
+  });
+
+  test("POST /activate-license is rate limited with configurable limits", async () => {
+    const app = createTestApp({
+      getMongoConnected: () => true,
+      rateLimitOptions: { windowMs: 60 * 1000, limit: 1 },
+    });
+
+    const firstResponse = await request(app)
+      .post("/activate-license")
+      .send({});
+    const secondResponse = await request(app)
+      .post("/activate-license")
+      .send({});
+
+    expect(firstResponse.status).toBe(400);
+    expect(secondResponse.status).toBe(429);
   });
 
   test("returns structured error when license key is missing", async () => {

--- a/index.js
+++ b/index.js
@@ -12,8 +12,11 @@ let mongoConnected = false;
 const maxConnectAttempts = 5;
 const connectRetryDelayMs = 1000;
 const DEFAULT_VALIDATION_LIMIT = 3;
+const DEFAULT_LICENSE_STATUS = "active";
+const DEFAULT_MAX_ACTIVATIONS = 3;
 const DEFAULT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 const DEFAULT_RATE_LIMIT_MAX = 100;
+const ACTIVE_LICENSE_STATUSES = ["active", "revoked", "disabled"];
 
 const parseAllowedOrigins = (value) => {
   if (!value) {
@@ -98,6 +101,55 @@ const getValidLicenseKey = (key) => {
   return { value: trimmedKey };
 };
 
+const getValidDeviceId = (deviceId) => {
+  if (deviceId === undefined) {
+    return {
+      error: {
+        message: "Device ID is required",
+        code: "MISSING_DEVICE_ID",
+      },
+    };
+  }
+
+  if (typeof deviceId !== "string") {
+    return {
+      error: {
+        message: "Invalid device ID",
+        code: "INVALID_DEVICE_ID",
+      },
+    };
+  }
+
+  const trimmedDeviceId = deviceId.trim();
+  if (!trimmedDeviceId) {
+    return {
+      error: {
+        message: "Device ID is required",
+        code: "MISSING_DEVICE_ID",
+      },
+    };
+  }
+
+  return { value: trimmedDeviceId };
+};
+
+const getValidPluginVersion = (pluginVersion) => {
+  if (pluginVersion === undefined) {
+    return {};
+  }
+
+  if (typeof pluginVersion !== "string") {
+    return {
+      error: {
+        message: "Invalid plugin version",
+        code: "INVALID_PLUGIN_VERSION",
+      },
+    };
+  }
+
+  return { value: pluginVersion.trim() || "unknown" };
+};
+
 const getFindOneAndUpdateDocument = (result) => {
   if (!result) {
     return null;
@@ -126,6 +178,45 @@ const isValidValidationNumber = (value) =>
 const isValidStringArray = (value) =>
   Array.isArray(value) && value.every((item) => typeof item === "string");
 
+const isNonEmptyString = (value) => typeof value === "string" && value.trim();
+
+const isValidActivation = (activation) => {
+  if (!activation || typeof activation !== "object" || Array.isArray(activation)) {
+    return false;
+  }
+
+  if (
+    !isNonEmptyString(activation.activationId) ||
+    !isNonEmptyString(activation.deviceId) ||
+    !isNonEmptyString(activation.activationToken)
+  ) {
+    return false;
+  }
+
+  if (
+    !isMissingValue(activation.pluginVersion) &&
+    typeof activation.pluginVersion !== "string"
+  ) {
+    return false;
+  }
+
+  if (
+    !isMissingValue(activation.activatedAt) &&
+    typeof activation.activatedAt !== "string"
+  ) {
+    return false;
+  }
+
+  if (
+    !isMissingValue(activation.lastSeenAt) &&
+    typeof activation.lastSeenAt !== "string"
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
 const getLicenseShapeError = (license) => {
   if (!isMissingValue(license.validationNumber)) {
     if (!isValidValidationNumber(license.validationNumber)) {
@@ -148,13 +239,102 @@ const getLicenseShapeError = (license) => {
   return null;
 };
 
+const getActivationLicenseShapeError = (license) => {
+  if (!isMissingValue(license.status)) {
+    if (!ACTIVE_LICENSE_STATUSES.includes(license.status)) {
+      return "status";
+    }
+  }
+
+  if (!isMissingValue(license.maxActivations)) {
+    if (!Number.isInteger(license.maxActivations) || license.maxActivations < 0) {
+      return "maxActivations";
+    }
+  }
+
+  if (!isMissingValue(license.activations)) {
+    if (!Array.isArray(license.activations)) {
+      return "activations";
+    }
+
+    if (!license.activations.every(isValidActivation)) {
+      return "activations";
+    }
+  }
+
+  return null;
+};
+
+const getLicenseStatus = (license) =>
+  isMissingValue(license.status) ? DEFAULT_LICENSE_STATUS : license.status;
+
+const getMaxActivations = (license) =>
+  isMissingValue(license.maxActivations)
+    ? DEFAULT_MAX_ACTIVATIONS
+    : license.maxActivations;
+
+const getActivations = (license) =>
+  isMissingValue(license.activations) ? [] : license.activations;
+
 const generateSalt = () => crypto.randomBytes(16).toString("hex");
+
+const generateActivationId = () =>
+  `act_${crypto.randomBytes(12).toString("hex")}`;
 
 const generateValidationString = (licenseKey, salt, hmacSecret) =>
   crypto
     .createHmac("sha256", hmacSecret)
     .update(`${licenseKey}:${salt}`)
     .digest("hex");
+
+const generateActivationToken = ({
+  licenseKey,
+  deviceId,
+  activationId,
+  salt,
+  hmacSecret,
+}) =>
+  crypto
+    .createHmac("sha256", hmacSecret)
+    .update(`${licenseKey}:${deviceId}:${activationId}:${salt}`)
+    .digest("hex");
+
+const getActiveLicenseFilter = (licenseId) => ({
+  licenseId,
+  $or: [
+    { status: DEFAULT_LICENSE_STATUS },
+    { status: { $exists: false } },
+  ],
+});
+
+const getExistingActivationFilter = (licenseId, deviceId) => ({
+  ...getActiveLicenseFilter(licenseId),
+  activations: { $elemMatch: { deviceId } },
+});
+
+const getNewActivationFilter = (licenseId, deviceId) => ({
+  ...getActiveLicenseFilter(licenseId),
+  $nor: [{ activations: { $elemMatch: { deviceId } } }],
+  $expr: {
+    $lt: [
+      { $size: { $ifNull: ["$activations", []] } },
+      { $ifNull: ["$maxActivations", DEFAULT_MAX_ACTIVATIONS] },
+    ],
+  },
+});
+
+const getActivationResponseBody = (activation, reused = false) => ({
+  message: "OK",
+  activationId: activation.activationId,
+  activationToken: activation.activationToken,
+  activated: true,
+  ...(reused ? { reused: true } : {}),
+});
+
+const findActivationByDeviceId = (license, deviceId) =>
+  getActivations(license).find(
+    (activation) => activation.deviceId === deviceId
+  );
 
 const validateLicenseKey = async ({ key, collection, hmacSecret }) => {
   const { value: licenseToValidate, error: keyError } = getValidLicenseKey(key);
@@ -285,6 +465,213 @@ const validateLicenseKey = async ({ key, collection, hmacSecret }) => {
   };
 };
 
+const activateLicense = async ({
+  key,
+  deviceId,
+  pluginVersion,
+  collection,
+  hmacSecret,
+}) => {
+  const { value: licenseToActivate, error: keyError } = getValidLicenseKey(key);
+
+  if (keyError) {
+    return { status: 400, body: keyError };
+  }
+
+  const { value: validDeviceId, error: deviceIdError } =
+    getValidDeviceId(deviceId);
+
+  if (deviceIdError) {
+    return { status: 400, body: deviceIdError };
+  }
+
+  const { value: validPluginVersion, error: pluginVersionError } =
+    getValidPluginVersion(pluginVersion);
+
+  if (pluginVersionError) {
+    return { status: 400, body: pluginVersionError };
+  }
+
+  if (!collection) {
+    return {
+      status: 503,
+      body: {
+        message: "Database not ready",
+        code: "DATABASE_NOT_READY",
+      },
+    };
+  }
+
+  if (!hmacSecret) {
+    return {
+      status: 500,
+      body: {
+        message: "Internal Server Error",
+        code: "SERVER_CONFIGURATION_ERROR",
+      },
+    };
+  }
+
+  const existingLicense = await collection.findOne({
+    licenseId: licenseToActivate,
+  });
+
+  if (!existingLicense) {
+    return {
+      status: 403,
+      body: {
+        message: "Invalid license key",
+        code: "LICENSE_NOT_FOUND",
+      },
+    };
+  }
+
+  if (getActivationLicenseShapeError(existingLicense)) {
+    return licenseDocumentInvalid();
+  }
+
+  if (getLicenseStatus(existingLicense) !== DEFAULT_LICENSE_STATUS) {
+    return {
+      status: 403,
+      body: {
+        message: "License is not active",
+        code: "LICENSE_NOT_ACTIVE",
+      },
+    };
+  }
+
+  const now = new Date().toISOString();
+  const existingActivationUpdate = {
+    $set: {
+      "activations.$.lastSeenAt": now,
+      ...(validPluginVersion !== undefined
+        ? { "activations.$.pluginVersion": validPluginVersion }
+        : {}),
+    },
+  };
+
+  const existingActivationResult = await collection.findOneAndUpdate(
+    getExistingActivationFilter(licenseToActivate, validDeviceId),
+    existingActivationUpdate,
+    { returnDocument: "after" }
+  );
+  const existingActivationLicense = getFindOneAndUpdateDocument(
+    existingActivationResult
+  );
+
+  if (existingActivationLicense) {
+    const activation = findActivationByDeviceId(
+      existingActivationLicense,
+      validDeviceId
+    );
+
+    if (!activation || getActivationLicenseShapeError(existingActivationLicense)) {
+      return licenseDocumentInvalid();
+    }
+
+    return {
+      status: 200,
+      body: getActivationResponseBody(activation, true),
+    };
+  }
+
+  const activationId = generateActivationId();
+  const activationSalt = generateSalt();
+  const activationToken = generateActivationToken({
+    licenseKey: licenseToActivate,
+    deviceId: validDeviceId,
+    activationId,
+    salt: activationSalt,
+    hmacSecret,
+  });
+  const activation = {
+    activationId,
+    deviceId: validDeviceId,
+    activationToken,
+    ...(validPluginVersion !== undefined
+      ? { pluginVersion: validPluginVersion }
+      : {}),
+    activatedAt: now,
+    lastSeenAt: now,
+  };
+
+  const newActivationResult = await collection.findOneAndUpdate(
+    getNewActivationFilter(licenseToActivate, validDeviceId),
+    {
+      $push: {
+        activations: activation,
+      },
+    },
+    { returnDocument: "after" }
+  );
+  const newActivationLicense = getFindOneAndUpdateDocument(newActivationResult);
+
+  if (newActivationLicense) {
+    return {
+      status: 200,
+      body: getActivationResponseBody(activation),
+    };
+  }
+
+  const fallbackLicense = await collection.findOne({
+    licenseId: licenseToActivate,
+  });
+
+  if (!fallbackLicense) {
+    return {
+      status: 403,
+      body: {
+        message: "Invalid license key",
+        code: "LICENSE_NOT_FOUND",
+      },
+    };
+  }
+
+  if (getActivationLicenseShapeError(fallbackLicense)) {
+    return licenseDocumentInvalid();
+  }
+
+  if (getLicenseStatus(fallbackLicense) !== DEFAULT_LICENSE_STATUS) {
+    return {
+      status: 403,
+      body: {
+        message: "License is not active",
+        code: "LICENSE_NOT_ACTIVE",
+      },
+    };
+  }
+
+  const fallbackActivation = findActivationByDeviceId(
+    fallbackLicense,
+    validDeviceId
+  );
+
+  if (fallbackActivation) {
+    return {
+      status: 200,
+      body: getActivationResponseBody(fallbackActivation, true),
+    };
+  }
+
+  if (getActivations(fallbackLicense).length >= getMaxActivations(fallbackLicense)) {
+    return {
+      status: 429,
+      body: {
+        message: "No more activations",
+        code: "ACTIVATION_LIMIT_REACHED",
+      },
+    };
+  }
+
+  return {
+    status: 500,
+    body: {
+      message: "Internal Server Error",
+      code: "ACTIVATION_UPDATE_FAILED",
+    },
+  };
+};
+
 const createMongoCollectionProvider = (url) => {
   let clientPromise;
   let collection;
@@ -339,10 +726,10 @@ const createApp = ({
     res.status(statusCode).json({ status: "ok", mongoConnected: connected });
   });
 
-  app.use(
-    "/validate-license",
-    rateLimiter || createValidationRateLimiter(rateLimitOptions)
-  );
+  const validationRateLimiter =
+    rateLimiter || createValidationRateLimiter(rateLimitOptions);
+
+  app.use(["/validate-license", "/activate-license"], validationRateLimiter);
 
   const handleValidateLicense = async (key, res) => {
     try {
@@ -372,6 +759,25 @@ const createApp = ({
 
   app.post("/validate-license", async (req, res) => {
     await handleValidateLicense(req.body && req.body.key, res);
+  });
+
+  app.post("/activate-license", async (req, res) => {
+    try {
+      const result = await activateLicense({
+        key: req.body && req.body.key,
+        deviceId: req.body && req.body.deviceId,
+        pluginVersion: req.body && req.body.pluginVersion,
+        collection: await getLicensesCollection(),
+        hmacSecret,
+      });
+      res.status(result.status).json(result.body);
+    } catch (error) {
+      console.error("Failed to activate license using MongoDB:", error);
+      res.status(500).json({
+        message: "Internal Server Error",
+        code: "INTERNAL_SERVER_ERROR",
+      });
+    }
   });
 
   return app;

--- a/licenses.json
+++ b/licenses.json
@@ -1,15 +1,24 @@
 [
   {
     "licenseId": "sample-license-key-001",
-    "validationNumber": 0,
-    "validationStrings": [],
-    "saltStrings": []
+    "status": "active",
+    "maxActivations": 3,
+    "activations": []
   },
   {
     "licenseId": "sample-license-key-002",
-    "validationNumber": 0,
-    "validationStrings": [],
-    "saltStrings": []
+    "status": "active",
+    "maxActivations": 1,
+    "activations": [
+      {
+        "activationId": "act_sample001",
+        "deviceId": "sample-device-hash",
+        "activationToken": "sample-token",
+        "pluginVersion": "1.0.0",
+        "activatedAt": "2026-06-14T00:00:00.000Z",
+        "lastSeenAt": "2026-06-14T00:00:00.000Z"
+      }
+    ]
   },
   {
     "licenseId": "sample-license-key-003",


### PR DESCRIPTION
## Summary
- Add `POST /activate-license` for Photoshop plugin activation with `key`, `deviceId`, and optional `pluginVersion`.
- Store/reuse activation records with `activationId`, `activationToken`, timestamps, and device metadata.
- Preserve existing `POST /validate-license` and deprecated `GET /validate-license` behavior.
- Document the new activation model in README and AGENTS, and refresh sample license data.

## Atomicity
- Existing-device activation uses a conditional `findOneAndUpdate` and does not consume another slot.
- New-device activation uses a conditional `findOneAndUpdate` with an activation-count `$expr` filter so concurrent requests cannot exceed `maxActivations`.
- Fallback lookup only classifies unknown, inactive, full, malformed, or unexpected states.

## Validation
- `node -c index.js`
- `node -e "JSON.parse(require('fs').readFileSync('licenses.json', 'utf8'))"`
- `git diff --check`
- `npm test` (60 tests passing)

## Notes
- No lint/typecheck scripts are configured beyond `npm test`.