### PR TITLE
[codex] Add license creation script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This is a small Node.js/Express license activation and validation API. The main 
 - `npm install`: install dependencies from `package-lock.json`.
 - `npm start`: run `node index.js` locally on `PORT` or `3000`.
 - `npm test`: run the Jest/Supertest suite.
+- `npm run create-license`: create an activation-model license document in MongoDB for seller/admin use.
 
 Local startup requires `MONGODB_URI` and `HMAC_SECRET`:
 
@@ -25,6 +26,8 @@ Use `POST /activate-license` with JSON body `{ "key": "...", "deviceId": "...", 
 License validation must stay atomic: enforce the validation limit in MongoDB with `findOneAndUpdate`, `$inc`, and `$push`. Do not reintroduce read-then-write validation count logic. Legacy license documents may omit `validationNumber`, `validationStrings`, or `saltStrings`; existing values for those fields must have the expected number/array types and malformed documents should fail with a controlled server error.
 
 Activation logic must also stay atomic. Same-device reactivation must reuse the existing activation and must not consume another slot. New-device activation must only append an activation record when the license is active and the current activation count is below `maxActivations`. Legacy activation records may omit `status`, `maxActivations`, or `activations`; existing values must have the documented types and malformed documents should fail safely.
+
+Generate new customer licenses locally with `npm run create-license`; the script loads `.env` from the project root if present. New license records should use the activation model (`status`, `maxActivations`, `activations`, timestamps, `source`) and should not include legacy `validationNumber`, `validationStrings`, or `saltStrings` fields. Do not add public license creation endpoints without authentication and explicit approval.
 
 ## Coding Style & Naming Conventions
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,39 @@ npm test
 
 There are no lint or typecheck scripts configured.
 
+## Admin: Create a License
+
+Use the local admin script to create license records before customers activate them. This script is for the seller/admin only; it is not used by the Photoshop plugin and should not be exposed as a public unauthenticated API.
+
+```bash
+export MONGODB_URI="mongodb+srv://user:pass@cluster.example.net"
+npm run create-license
+```
+
+The script also loads `.env` from the project root when present. Exported shell variables take precedence over `.env` values.
+
+Optional arguments:
+
+```bash
+npm run create-license -- --max-activations 3 --source manual --prefix PSP
+```
+
+The script generates a readable license key such as `PSP-K7M9-Q2XA-84PD` and inserts an activation-model document:
+
+```js
+{
+  licenseId: "PSP-K7M9-Q2XA-84PD",
+  status: "active",
+  maxActivations: 3,
+  activations: [],
+  createdAt: "2026-06-14T00:00:00.000Z",
+  updatedAt: "2026-06-14T00:00:00.000Z",
+  source: "script"
+}
+```
+
+Give the generated `licenseId` to the customer. The customer activates it later through the plugin UI. The script uses `MONGODB_DATABASE` and `LICENSE_COLLECTION` when set; otherwise it uses `licenseDatabase.licenses`. It does not require `HMAC_SECRET`.
+
 ## Deployment Notes
 
 The app supports local long-running server mode with `npm start` and Vercel/serverless import through `index.js`. Do not call `app.listen()` in serverless mode; the exported Express app is used by the platform.

--- a/__tests__/createLicense.test.js
+++ b/__tests__/createLicense.test.js
@@ -1,0 +1,157 @@
+const {
+  buildLicenseDocument,
+  generateLicenseKey,
+  insertLicenseWithRetry,
+  loadDotEnv,
+  parseDotEnvLine,
+  parseCreateLicenseArgs,
+  run,
+} = require("../scripts/createLicense");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+describe("create license script helpers", () => {
+  test("generates readable Photoshop license keys", () => {
+    const licenseKey = generateLicenseKey({ prefix: "PSP" });
+
+    expect(licenseKey).toMatch(
+      /^PSP-[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}$/
+    );
+    expect(licenseKey).not.toMatch(/[O0I1]/);
+  });
+
+  test("parses default create license options", () => {
+    expect(parseCreateLicenseArgs([])).toEqual({
+      maxActivations: 3,
+      source: "script",
+      prefix: "PSP",
+    });
+  });
+
+  test("parses dotenv lines", () => {
+    expect(parseDotEnvLine("MONGODB_URI=mongodb://example")).toEqual({
+      key: "MONGODB_URI",
+      value: "mongodb://example",
+    });
+    expect(parseDotEnvLine("HMAC_SECRET=\"quoted-secret\"")).toEqual({
+      key: "HMAC_SECRET",
+      value: "quoted-secret",
+    });
+    expect(parseDotEnvLine("# ignored")).toBeNull();
+  });
+
+  test("loads dotenv values without overriding exported variables", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "license-env-"));
+    const filePath = path.join(directory, ".env");
+    const env = {
+      MONGODB_URI: "mongodb://exported",
+    };
+
+    fs.writeFileSync(
+      filePath,
+      [
+        "MONGODB_URI=mongodb://from-file",
+        "MONGODB_DATABASE=licenseDatabase",
+      ].join("\n")
+    );
+
+    loadDotEnv({ env, filePath });
+
+    expect(env).toEqual({
+      MONGODB_URI: "mongodb://exported",
+      MONGODB_DATABASE: "licenseDatabase",
+    });
+  });
+
+  test("parses explicit create license options", () => {
+    expect(
+      parseCreateLicenseArgs([
+        "--max-activations",
+        "1",
+        "--source",
+        "manual",
+        "--prefix",
+        "psx",
+      ])
+    ).toEqual({
+      maxActivations: 1,
+      source: "manual",
+      prefix: "PSX",
+    });
+  });
+
+  test("rejects invalid max activations", () => {
+    expect(() =>
+      parseCreateLicenseArgs(["--max-activations", "0"])
+    ).toThrow("--max-activations must be a positive integer.");
+  });
+
+  test("builds activation-model license documents", () => {
+    const license = buildLicenseDocument({
+      licenseId: "PSP-K7M9-Q2XA-84PD",
+      maxActivations: 2,
+      source: "manual",
+      now: new Date("2026-06-14T00:00:00.000Z"),
+    });
+
+    expect(license).toEqual({
+      licenseId: "PSP-K7M9-Q2XA-84PD",
+      status: "active",
+      maxActivations: 2,
+      activations: [],
+      createdAt: "2026-06-14T00:00:00.000Z",
+      updatedAt: "2026-06-14T00:00:00.000Z",
+      source: "manual",
+    });
+    expect(license).not.toHaveProperty("validationNumber");
+    expect(license).not.toHaveProperty("validationStrings");
+    expect(license).not.toHaveProperty("saltStrings");
+  });
+
+  test("retries duplicate license keys", async () => {
+    const duplicateError = new Error("duplicate key");
+    duplicateError.code = 11000;
+    const collection = {
+      insertOne: jest
+        .fn()
+        .mockRejectedValueOnce(duplicateError)
+        .mockResolvedValueOnce({ acknowledged: true }),
+    };
+
+    const license = await insertLicenseWithRetry({
+      collection,
+      prefix: "PSP",
+      maxActivations: 3,
+      source: "script",
+      attempts: 2,
+    });
+
+    expect(collection.insertOne).toHaveBeenCalledTimes(2);
+    expect(license.licenseId).toMatch(
+      /^PSP-[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}$/
+    );
+  });
+
+  test("missing MONGODB_URI exits with a clear error", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const originalExitCode = process.exitCode;
+
+    await run({
+      args: [],
+      env: {},
+      dotEnvFilePath: path.join(os.tmpdir(), "missing-license-env-file"),
+      MongoClientClass: jest.fn(),
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Missing required environment variable MONGODB_URI."
+    );
+    expect(process.exitCode).toBe(1);
+
+    process.exitCode = originalExitCode;
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Express API for validating MongoDB-backed software license keys.",
   "main": "index.js",
   "scripts": {
+    "create-license": "node scripts/createLicense.js",
     "start": "node index.js",
     "test": "jest"
   },

--- a/scripts/createLicense.js
+++ b/scripts/createLicense.js
@@ -1,0 +1,278 @@
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const { MongoClient } = require("mongodb");
+
+const DEFAULT_DATABASE_NAME = "licenseDatabase";
+const DEFAULT_COLLECTION_NAME = "licenses";
+const DEFAULT_PREFIX = "PSP";
+const DEFAULT_MAX_ACTIVATIONS = 3;
+const DEFAULT_SOURCE = "script";
+const MAX_DUPLICATE_ATTEMPTS = 5;
+const LICENSE_CHARACTERS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+const parseDotEnvLine = (line) => {
+  const trimmedLine = line.trim();
+
+  if (!trimmedLine || trimmedLine.startsWith("#")) {
+    return null;
+  }
+
+  const equalsIndex = trimmedLine.indexOf("=");
+
+  if (equalsIndex === -1) {
+    return null;
+  }
+
+  const key = trimmedLine.slice(0, equalsIndex).trim();
+  let value = trimmedLine.slice(equalsIndex + 1).trim();
+
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+    return null;
+  }
+
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    value = value.slice(1, -1);
+  }
+
+  return { key, value };
+};
+
+const loadDotEnv = ({
+  env = process.env,
+  filePath = path.join(process.cwd(), ".env"),
+} = {}) => {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+
+  const contents = fs.readFileSync(filePath, "utf8");
+
+  contents.split(/\r?\n/).forEach((line) => {
+    const parsedLine = parseDotEnvLine(line);
+
+    if (!parsedLine || env[parsedLine.key] !== undefined) {
+      return;
+    }
+
+    env[parsedLine.key] = parsedLine.value;
+  });
+};
+
+const parsePositiveInteger = (value, optionName) => {
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isInteger(parsed) || parsed <= 0 || String(parsed) !== String(value)) {
+    throw new Error(`${optionName} must be a positive integer.`);
+  }
+
+  return parsed;
+};
+
+const requireOptionValue = (args, index, optionName) => {
+  const value = args[index + 1];
+
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${optionName} requires a value.`);
+  }
+
+  return value;
+};
+
+const parseCreateLicenseArgs = (args = process.argv.slice(2)) => {
+  const options = {
+    maxActivations: DEFAULT_MAX_ACTIVATIONS,
+    source: DEFAULT_SOURCE,
+    prefix: DEFAULT_PREFIX,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "--max-activations") {
+      const value = requireOptionValue(args, index, arg);
+      options.maxActivations = parsePositiveInteger(value, arg);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--source") {
+      options.source = requireOptionValue(args, index, arg);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--prefix") {
+      options.prefix = requireOptionValue(args, index, arg).toUpperCase();
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown option ${arg}.`);
+  }
+
+  if (!/^[A-Z]{2,10}$/.test(options.prefix)) {
+    throw new Error("--prefix must contain 2 to 10 letters.");
+  }
+
+  return options;
+};
+
+const randomLicenseCharacter = () =>
+  LICENSE_CHARACTERS[
+    crypto.randomInt(0, LICENSE_CHARACTERS.length)
+  ];
+
+const generateLicenseKey = ({
+  prefix = DEFAULT_PREFIX,
+  groups = 3,
+  groupLength = 4,
+} = {}) => {
+  const keyGroups = [];
+
+  for (let groupIndex = 0; groupIndex < groups; groupIndex += 1) {
+    let group = "";
+
+    for (let charIndex = 0; charIndex < groupLength; charIndex += 1) {
+      group += randomLicenseCharacter();
+    }
+
+    keyGroups.push(group);
+  }
+
+  return `${prefix}-${keyGroups.join("-")}`;
+};
+
+const buildLicenseDocument = ({
+  licenseId,
+  maxActivations = DEFAULT_MAX_ACTIVATIONS,
+  source = DEFAULT_SOURCE,
+  now = new Date(),
+}) => {
+  const timestamp = now.toISOString();
+
+  return {
+    licenseId,
+    status: "active",
+    maxActivations,
+    activations: [],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    source,
+  };
+};
+
+const isDuplicateKeyError = (error) => error && error.code === 11000;
+
+const insertLicenseWithRetry = async ({
+  collection,
+  prefix,
+  maxActivations,
+  source,
+  attempts = MAX_DUPLICATE_ATTEMPTS,
+}) => {
+  let lastDuplicateError;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const licenseId = generateLicenseKey({ prefix });
+    const license = buildLicenseDocument({
+      licenseId,
+      maxActivations,
+      source,
+    });
+
+    try {
+      await collection.insertOne(license);
+      return license;
+    } catch (error) {
+      if (!isDuplicateKeyError(error)) {
+        throw error;
+      }
+
+      lastDuplicateError = error;
+    }
+  }
+
+  throw new Error(
+    `Failed to generate a unique license key after ${attempts} attempts.${
+      lastDuplicateError ? ` Last duplicate error: ${lastDuplicateError.message}` : ""
+    }`
+  );
+};
+
+const printLicenseSummary = (license) => {
+  console.log("License created");
+  console.log("");
+  console.log(`License ID: ${license.licenseId}`);
+  console.log(`Status: ${license.status}`);
+  console.log(`Max activations: ${license.maxActivations}`);
+  console.log(`Source: ${license.source}`);
+};
+
+const run = async ({
+  args = process.argv.slice(2),
+  env = process.env,
+  dotEnvFilePath,
+  MongoClientClass = MongoClient,
+} = {}) => {
+  loadDotEnv({
+    env,
+    ...(dotEnvFilePath ? { filePath: dotEnvFilePath } : {}),
+  });
+
+  if (!env.MONGODB_URI) {
+    console.error("Missing required environment variable MONGODB_URI.");
+    process.exitCode = 1;
+    return;
+  }
+
+  let options;
+
+  try {
+    options = parseCreateLicenseArgs(args);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+    return;
+  }
+
+  const client = new MongoClientClass(env.MONGODB_URI);
+
+  try {
+    await client.connect();
+    const db = client.db(env.MONGODB_DATABASE || DEFAULT_DATABASE_NAME);
+    const collection = db.collection(
+      env.LICENSE_COLLECTION || DEFAULT_COLLECTION_NAME
+    );
+    const license = await insertLicenseWithRetry({
+      collection,
+      prefix: options.prefix,
+      maxActivations: options.maxActivations,
+      source: options.source,
+    });
+
+    printLicenseSummary(license);
+  } catch (error) {
+    console.error(`Failed to create license: ${error.message}`);
+    process.exitCode = 1;
+  } finally {
+    await client.close();
+  }
+};
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = {
+  buildLicenseDocument,
+  generateLicenseKey,
+  insertLicenseWithRetry,
+  loadDotEnv,
+  parseDotEnvLine,
+  parseCreateLicenseArgs,
+  run,
+};


### PR DESCRIPTION
## Summary
- Add `npm run create-license` for seller/admin license record generation.
- Generate readable `PSP-XXXX-XXXX-XXXX` license IDs with Node crypto.
- Insert activation-model MongoDB documents with `status`, `maxActivations`, `activations`, timestamps, and `source`.
- Load `.env` from the project root for the script while preserving exported shell variable precedence.
- Add helper tests and README/AGENTS documentation.

## Behavior
- Requires `MONGODB_URI`; does not require `HMAC_SECRET`.
- Supports `--max-activations`, `--source`, and `--prefix`.
- Retries duplicate key errors instead of overwriting existing licenses.
- Does not add legacy validation fields to new license records.

## Validation
- `node -c index.js`
- `node -c scripts/createLicense.js`
- `git diff --check`
- `npm test` (72 tests passing)

## Manual testing
- Ran `npm run create-license` without `MONGODB_URI` before `.env` loading and confirmed the clear missing-env error.
- Did not run a real MongoDB insert after `.env` loading to avoid creating a real license in the configured database.