### PR TITLE
[codex] Add admin license UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ License validation must stay atomic: enforce the validation limit in MongoDB wit
 
 Activation logic must also stay atomic. Same-device reactivation must reuse the existing activation and must not consume another slot. New-device activation must only append an activation record when the license is active and the current activation count is below `maxActivations`. Legacy activation records may omit `status`, `maxActivations`, or `activations`; existing values must have the documented types and malformed documents should fail safely.
 
+Admin UI routes live under `/admin` and must stay protected by HTTP Basic Auth with `ADMIN_USERNAME` and `ADMIN_PASSWORD`. Do not add unauthenticated license creation endpoints. Admin-created licenses must use the activation model and must not include legacy validation fields.
+
 Generate new customer licenses locally with `npm run create-license`; the script loads `.env` from the project root if present. New license records should use the activation model (`status`, `maxActivations`, `activations`, timestamps, `source`) and should not include legacy `validationNumber`, `validationStrings`, or `saltStrings` fields. Do not add public license creation endpoints without authentication and explicit approval.
 
 ## Coding Style & Naming Conventions
@@ -43,4 +45,4 @@ Keep commits focused and imperative, such as `Add POST license validation`. Pull
 
 ## Security & Configuration Tips
 
-Do not commit secrets, real MongoDB credentials, or production license data. Required runtime env vars are `MONGODB_URI` and `HMAC_SECRET`; optional HTTP/deployment vars include `ALLOWED_ORIGINS`, `ALLOW_NULL_ORIGIN`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `TRUST_PROXY`, `PORT`, and `NODE_ENV`. Adobe/plugin runtimes may send `Origin: null`; only enable that with `ALLOW_NULL_ORIGIN=true` when needed. Do not treat CORS as the licensing security boundary. Restrict browser origins in production and treat in-memory rate limiting as best-effort in serverless environments. Never put backend secrets in Photoshop plugin code; device IDs should be stable opaque hashes rather than sensitive raw personal data.
+Do not commit secrets, real MongoDB credentials, admin credentials, or production license data. Required runtime env vars are `MONGODB_URI` and `HMAC_SECRET`; admin routes require `ADMIN_USERNAME` and `ADMIN_PASSWORD`; optional HTTP/deployment vars include `ALLOWED_ORIGINS`, `ALLOW_NULL_ORIGIN`, `RATE_LIMIT_WINDOW_MS`, `RATE_LIMIT_MAX`, `TRUST_PROXY`, `PORT`, and `NODE_ENV`. Adobe/plugin runtimes may send `Origin: null`; only enable that with `ALLOW_NULL_ORIGIN=true` when needed. Do not treat CORS as the licensing security boundary. Restrict browser origins in production and treat in-memory rate limiting as best-effort in serverless environments. Never put backend secrets in Photoshop plugin code; device IDs should be stable opaque hashes rather than sensitive raw personal data.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Deprecated but temporarily supported for backward compatibility. GET responses i
 | --- | --- | --- | --- | --- |
 | `MONGODB_URI` | Yes for startup/deploy | None | `mongodb+srv://user:pass@cluster.example.net` | MongoDB connection. |
 | `HMAC_SECRET` | Yes for startup/deploy | None | `replace-with-a-long-random-secret` | Server-side HMAC key for validation strings. |
+| `ADMIN_USERNAME` | Yes for admin UI | None | `admin` | HTTP Basic Auth username for `/admin` routes. |
+| `ADMIN_PASSWORD` | Yes for admin UI | None | `use-a-long-random-password` | HTTP Basic Auth password for `/admin` routes. |
 | `PORT` | No | `3000` | `3000` | Local server port for `npm start`. |
 | `ALLOWED_ORIGINS` | No | No browser CORS origins | `https://example.com,https://app.example.com` | Comma-separated browser origins allowed by CORS. |
 | `ALLOW_NULL_ORIGIN` | No | `false` | `true` | Allows `Origin: null` for Adobe/plugin/package/file-like runtimes. |
@@ -150,6 +152,8 @@ For legacy records, `validationNumber`, `validationStrings`, and `saltStrings` m
 npm install
 export MONGODB_URI="mongodb+srv://user:pass@cluster.example.net"
 export HMAC_SECRET="replace-with-a-long-random-secret"
+export ADMIN_USERNAME="admin"
+export ADMIN_PASSWORD="use-a-long-random-password"
 npm start
 ```
 
@@ -160,6 +164,24 @@ npm test
 ```
 
 There are no lint or typecheck scripts configured.
+
+## Admin UI
+
+The private admin UI is available under `/admin` and redirects to `/admin/licenses`. It is protected with HTTP Basic Auth using `ADMIN_USERNAME` and `ADMIN_PASSWORD`; if those variables are missing, admin routes are not accessible. Do not put admin credentials in the Photoshop plugin.
+
+Admin routes:
+
+```txt
+GET  /admin
+GET  /admin/licenses
+GET  /admin/licenses/new
+POST /admin/licenses
+GET  /admin/licenses/:licenseId
+POST /admin/licenses/:licenseId/status
+POST /admin/licenses/:licenseId/reset-activations
+```
+
+Use `/admin/licenses` to create licenses before customers activate them, view activation records, set status to `active`, `revoked`, or `disabled`, and reset activations for support cases. Generated license IDs are what you send to customers. Do not expose license creation as a public unauthenticated API.
 
 ## Admin: Create a License
 
@@ -196,7 +218,7 @@ Give the generated `licenseId` to the customer. The customer activates it later 
 
 ## Deployment Notes
 
-The app supports local long-running server mode with `npm start` and Vercel/serverless import through `index.js`. Do not call `app.listen()` in serverless mode; the exported Express app is used by the platform.
+The app supports local long-running server mode with `npm start` and Vercel/serverless import through `index.js`. Do not call `app.listen()` in serverless mode; the exported Express app is used by the platform. If the admin UI is enabled on Vercel, configure `ADMIN_USERNAME` and `ADMIN_PASSWORD` there as environment variables.
 
 CORS is handled by the Express app. Set `ALLOWED_ORIGINS` for normal browser/web origins instead of using wildcard static headers. Requests without an `Origin` header still work for server-to-server clients, `curl`, health checks, and plugin runtimes that omit the header.
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -11,6 +11,17 @@ const createTestApp = (options = {}) =>
     hmacSecret: TEST_HMAC_SECRET,
     ...options,
   });
+const adminAuth = (username = "admin", password = "secret") =>
+  `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+const createAdminTestApp = (collection, options = {}) =>
+  createTestApp({
+    getLicensesCollection: () => collection,
+    getMongoConnected: () => true,
+    rateLimiter: noRateLimit,
+    adminUsername: "admin",
+    adminPassword: "secret",
+    ...options,
+  });
 const atomicValidationFilter = (licenseId) => ({
   licenseId,
   $or: [
@@ -47,6 +58,15 @@ const existingActivation = {
   pluginVersion: "1.0.0",
   activatedAt: "2026-06-14T00:00:00.000Z",
   lastSeenAt: "2026-06-14T00:00:00.000Z",
+};
+const createFindCursor = (licenses) => {
+  const cursor = {
+    sort: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    toArray: jest.fn().mockResolvedValue(licenses),
+  };
+
+  return cursor;
 };
 
 describe("license validator service", () => {
@@ -207,6 +227,260 @@ describe("license validator service", () => {
         process.env.VERCEL = originalVercel;
       }
     }
+  });
+
+  test("admin license list requires basic auth", async () => {
+    const collection = {
+      find: jest.fn(),
+    };
+    const app = createAdminTestApp(collection);
+
+    const response = await request(app).get("/admin/licenses");
+
+    expect(response.status).toBe(401);
+    expect(response.headers["www-authenticate"]).toBe(
+      'Basic realm="License Admin"'
+    );
+    expect(collection.find).not.toHaveBeenCalled();
+  });
+
+  test("admin license list rejects wrong basic auth", async () => {
+    const app = createAdminTestApp({ find: jest.fn() });
+
+    const response = await request(app)
+      .get("/admin/licenses")
+      .set("Authorization", adminAuth("admin", "wrong"));
+
+    expect(response.status).toBe(401);
+  });
+
+  test("admin routes return 503 when credentials are not configured", async () => {
+    const app = createTestApp({
+      getMongoConnected: () => true,
+      rateLimiter: noRateLimit,
+    });
+
+    const response = await request(app)
+      .get("/admin/licenses")
+      .set("Authorization", adminAuth());
+
+    expect(response.status).toBe(503);
+    expect(response.text).toContain("Admin UI is not configured.");
+  });
+
+  test("admin license list renders licenses and used activation counts", async () => {
+    const cursor = createFindCursor([
+      {
+        licenseId: "PSP-ABCD-EFGH-JKLM",
+        status: "active",
+        maxActivations: 3,
+        activations: [existingActivation, { ...existingActivation, deviceId: "device-2" }],
+        source: "admin-ui",
+        createdAt: "2026-06-14T00:00:00.000Z",
+      },
+    ]);
+    const collection = {
+      find: jest.fn().mockReturnValue(cursor),
+    };
+    const app = createAdminTestApp(collection);
+
+    const response = await request(app)
+      .get("/admin/licenses")
+      .set("Authorization", adminAuth());
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain("PSP-ABCD-EFGH-JKLM");
+    expect(response.text).toContain("admin-ui");
+    expect(response.text).toContain("<td>2</td>");
+    expect(collection.find).toHaveBeenCalledWith({});
+    expect(cursor.sort).toHaveBeenCalledWith({ createdAt: -1 });
+    expect(cursor.limit).toHaveBeenCalledWith(100);
+  });
+
+  test("admin can create an activation-model license", async () => {
+    const collection = {
+      insertOne: jest.fn().mockResolvedValue({ acknowledged: true }),
+    };
+    const app = createAdminTestApp(collection);
+
+    const response = await request(app)
+      .post("/admin/licenses")
+      .set("Authorization", adminAuth())
+      .type("form")
+      .send({
+        prefix: "PSP",
+        maxActivations: "3",
+        source: "admin-ui",
+      });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.location).toMatch(
+      /^\/admin\/licenses\/PSP-[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}\?created=1$/
+    );
+    expect(collection.insertOne).toHaveBeenCalledTimes(1);
+
+    const insertedLicense = collection.insertOne.mock.calls[0][0];
+    expect(insertedLicense).toEqual({
+      licenseId: expect.stringMatching(
+        /^PSP-[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}$/
+      ),
+      status: "active",
+      maxActivations: 3,
+      activations: [],
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+      source: "admin-ui",
+    });
+    expect(insertedLicense).not.toHaveProperty("validationNumber");
+    expect(insertedLicense).not.toHaveProperty("validationStrings");
+    expect(insertedLicense).not.toHaveProperty("saltStrings");
+  });
+
+  test("admin license creation supports custom max activations and duplicate retry", async () => {
+    const duplicateError = new Error("duplicate");
+    duplicateError.code = 11000;
+    const collection = {
+      insertOne: jest
+        .fn()
+        .mockRejectedValueOnce(duplicateError)
+        .mockResolvedValueOnce({ acknowledged: true }),
+    };
+    const app = createAdminTestApp(collection);
+
+    const response = await request(app)
+      .post("/admin/licenses")
+      .set("Authorization", adminAuth())
+      .type("form")
+      .send({
+        prefix: "PSX",
+        maxActivations: "1",
+        source: "support",
+      });
+
+    expect(response.status).toBe(303);
+    expect(collection.insertOne).toHaveBeenCalledTimes(2);
+    expect(collection.insertOne.mock.calls[1][0]).toEqual(
+      expect.objectContaining({
+        licenseId: expect.stringMatching(
+          /^PSX-[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}$/
+        ),
+        maxActivations: 1,
+        source: "support",
+      })
+    );
+  });
+
+  test("admin license detail shows activation records", async () => {
+    const collection = {
+      findOne: jest.fn().mockResolvedValue({
+        licenseId: "PSP-ABCD-EFGH-JKLM",
+        status: "active",
+        maxActivations: 3,
+        activations: [existingActivation],
+        source: "admin-ui",
+        createdAt: "2026-06-14T00:00:00.000Z",
+        updatedAt: "2026-06-14T00:00:00.000Z",
+      }),
+    };
+    const app = createAdminTestApp(collection);
+
+    const response = await request(app)
+      .get("/admin/licenses/PSP-ABCD-EFGH-JKLM")
+      .set("Authorization", adminAuth());
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain("PSP-ABCD-EFGH-JKLM");
+    expect(response.text).toContain("act_existing");
+    expect(response.text).toContain("device-1");
+    expect(response.text).toContain("This will remove all activation records");
+    expect(collection.findOne).toHaveBeenCalledWith({
+      licenseId: "PSP-ABCD-EFGH-JKLM",
+    });
+  });
+
+  test("admin unknown license detail returns 404", async () => {
+    const app = createAdminTestApp({
+      findOne: jest.fn().mockResolvedValue(null),
+    });
+
+    const response = await request(app)
+      .get("/admin/licenses/missing")
+      .set("Authorization", adminAuth());
+
+    expect(response.status).toBe(404);
+    expect(response.text).toContain("License not found.");
+  });
+
+  test.each(["active", "revoked", "disabled"])(
+    "admin can set license status to %s",
+    async (status) => {
+      const collection = {
+        updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+      };
+      const app = createAdminTestApp(collection);
+
+      const response = await request(app)
+        .post("/admin/licenses/PSP-ABCD-EFGH-JKLM/status")
+        .set("Authorization", adminAuth())
+        .type("form")
+        .send({ status });
+
+      expect(response.status).toBe(303);
+      expect(response.headers.location).toBe(
+        "/admin/licenses/PSP-ABCD-EFGH-JKLM?statusUpdated=1"
+      );
+      expect(collection.updateOne).toHaveBeenCalledWith(
+        { licenseId: "PSP-ABCD-EFGH-JKLM" },
+        {
+          $set: {
+            status,
+            updatedAt: expect.any(String),
+          },
+        }
+      );
+    }
+  );
+
+  test("admin invalid status returns 400", async () => {
+    const collection = {
+      updateOne: jest.fn(),
+    };
+    const app = createAdminTestApp(collection);
+
+    const response = await request(app)
+      .post("/admin/licenses/PSP-ABCD-EFGH-JKLM/status")
+      .set("Authorization", adminAuth())
+      .type("form")
+      .send({ status: "pending" });
+
+    expect(response.status).toBe(400);
+    expect(response.text).toContain("Invalid license status.");
+    expect(collection.updateOne).not.toHaveBeenCalled();
+  });
+
+  test("admin can reset activations", async () => {
+    const collection = {
+      updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+    };
+    const app = createAdminTestApp(collection);
+
+    const response = await request(app)
+      .post("/admin/licenses/PSP-ABCD-EFGH-JKLM/reset-activations")
+      .set("Authorization", adminAuth());
+
+    expect(response.status).toBe(303);
+    expect(response.headers.location).toBe(
+      "/admin/licenses/PSP-ABCD-EFGH-JKLM?activationsReset=1"
+    );
+    expect(collection.updateOne).toHaveBeenCalledWith(
+      { licenseId: "PSP-ABCD-EFGH-JKLM" },
+      {
+        $set: {
+          activations: [],
+          updatedAt: expect.any(String),
+        },
+      }
+    );
   });
 
   test.each([

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const cors = require("cors");
 const crypto = require("crypto");
 const { MongoClient } = require("mongodb");
 const rateLimit = require("express-rate-limit");
+const { insertLicenseWithRetry } = require("./scripts/createLicense");
 
 const port = process.env.PORT || 3000;
 
@@ -17,6 +18,9 @@ const DEFAULT_MAX_ACTIVATIONS = 3;
 const DEFAULT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 const DEFAULT_RATE_LIMIT_MAX = 100;
 const ACTIVE_LICENSE_STATUSES = ["active", "revoked", "disabled"];
+const ADMIN_LICENSE_STATUSES = ["active", "revoked", "disabled"];
+const DEFAULT_ADMIN_LICENSE_SOURCE = "admin-ui";
+const DEFAULT_ADMIN_LICENSE_PREFIX = "PSP";
 
 const parseAllowedOrigins = (value) => {
   if (!value) {
@@ -34,6 +38,13 @@ const getPositiveInteger = (value, fallback) => {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 };
 
+const parsePositiveInteger = (value) => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 && String(parsed) === String(value)
+    ? parsed
+    : null;
+};
+
 const getBoolean = (value) => value === true || value === "true";
 
 const isVercelEnvironment = (value = process.env.VERCEL) =>
@@ -41,6 +52,58 @@ const isVercelEnvironment = (value = process.env.VERCEL) =>
 
 const shouldTrustProxy = () =>
   getBoolean(process.env.TRUST_PROXY) || isVercelEnvironment();
+
+const escapeHtml = (value) =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const renderAdminLayout = ({ title, body }) => `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>${escapeHtml(title)}</title>
+    <style>
+      body { color: #17202a; font-family: Arial, sans-serif; line-height: 1.5; margin: 32px; }
+      main { max-width: 1120px; }
+      table { border-collapse: collapse; margin: 16px 0; width: 100%; }
+      th, td { border: 1px solid #d8dee4; padding: 8px 10px; text-align: left; vertical-align: top; }
+      th { background: #f6f8fa; }
+      input, select, button { font: inherit; margin: 4px 0 12px; padding: 7px 9px; }
+      label { display: block; font-weight: 700; margin-top: 10px; }
+      .actions { display: flex; gap: 12px; margin: 16px 0; }
+      .danger { border: 1px solid #d1242f; padding: 12px; }
+      .muted { color: #57606a; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>${escapeHtml(title)}</h1>
+      <nav class="actions">
+        <a href="/admin/licenses">Licenses</a>
+        <a href="/admin/licenses/new">Create license</a>
+      </nav>
+      ${body}
+    </main>
+  </body>
+</html>`;
+
+const sendAdminHtml = (res, title, body, status = 200) => {
+  res.status(status).type("html").send(renderAdminLayout({ title, body }));
+};
+
+const renderAdminError = (res, status, message) => {
+  sendAdminHtml(
+    res,
+    "Admin Error",
+    `<p>${escapeHtml(message)}</p>`,
+    status
+  );
+};
 
 const createValidationRateLimiter = ({
   windowMs = getPositiveInteger(
@@ -341,6 +404,226 @@ const findActivationByDeviceId = (license, deviceId) =>
   getActivations(license).find(
     (activation) => activation.deviceId === deviceId
   );
+
+const getUsedActivations = (license) => getActivations(license).length;
+
+const getBasicAuthCredentials = (authorizationHeader) => {
+  if (!authorizationHeader || !authorizationHeader.startsWith("Basic ")) {
+    return null;
+  }
+
+  const encodedCredentials = authorizationHeader.slice("Basic ".length);
+
+  try {
+    const decodedCredentials = Buffer.from(
+      encodedCredentials,
+      "base64"
+    ).toString("utf8");
+    const separatorIndex = decodedCredentials.indexOf(":");
+
+    if (separatorIndex === -1) {
+      return null;
+    }
+
+    return {
+      username: decodedCredentials.slice(0, separatorIndex),
+      password: decodedCredentials.slice(separatorIndex + 1),
+    };
+  } catch (error) {
+    return null;
+  }
+};
+
+const valuesMatch = (actual, expected) => {
+  const actualBuffer = Buffer.from(String(actual));
+  const expectedBuffer = Buffer.from(String(expected));
+
+  if (actualBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(actualBuffer, expectedBuffer);
+};
+
+const createAdminAuthMiddleware = ({ adminUsername, adminPassword }) =>
+  (req, res, next) => {
+    if (!adminUsername || !adminPassword) {
+      renderAdminError(res, 503, "Admin UI is not configured.");
+      return;
+    }
+
+    const credentials = getBasicAuthCredentials(req.get("authorization"));
+    const authenticated =
+      credentials &&
+      valuesMatch(credentials.username, adminUsername) &&
+      valuesMatch(credentials.password, adminPassword);
+
+    if (!authenticated) {
+      res.set("WWW-Authenticate", 'Basic realm="License Admin"');
+      res.status(401).send("Unauthorized");
+      return;
+    }
+
+    next();
+  };
+
+const asyncRoute = (handler) => async (req, res, next) => {
+  try {
+    await handler(req, res, next);
+  } catch (error) {
+    next(error);
+  }
+};
+
+const renderLicenseRows = (licenses) =>
+  licenses
+    .map(
+      (license) => `
+        <tr>
+          <td><code>${escapeHtml(license.licenseId)}</code></td>
+          <td>${escapeHtml(getLicenseStatus(license))}</td>
+          <td>${escapeHtml(getMaxActivations(license))}</td>
+          <td>${escapeHtml(getUsedActivations(license))}</td>
+          <td>${escapeHtml(license.source || "")}</td>
+          <td>${escapeHtml(license.createdAt || "")}</td>
+          <td><a href="/admin/licenses/${encodeURIComponent(license.licenseId)}">View</a></td>
+        </tr>`
+    )
+    .join("");
+
+const renderLicenseList = (licenses) => `
+  <p><a href="/admin/licenses/new">Create a new license</a></p>
+  <table>
+    <thead>
+      <tr>
+        <th>License ID</th>
+        <th>Status</th>
+        <th>Max activations</th>
+        <th>Used activations</th>
+        <th>Source</th>
+        <th>Created at</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${
+        licenses.length
+          ? renderLicenseRows(licenses)
+          : '<tr><td colspan="7">No licenses found.</td></tr>'
+      }
+    </tbody>
+  </table>`;
+
+const renderNewLicenseForm = () => `
+  <form method="post" action="/admin/licenses">
+    <label for="prefix">Prefix</label>
+    <input id="prefix" name="prefix" value="${DEFAULT_ADMIN_LICENSE_PREFIX}" required>
+
+    <label for="maxActivations">Max activations</label>
+    <input id="maxActivations" name="maxActivations" type="number" min="1" value="${DEFAULT_MAX_ACTIVATIONS}" required>
+
+    <label for="source">Source</label>
+    <input id="source" name="source" value="${DEFAULT_ADMIN_LICENSE_SOURCE}" required>
+
+    <button type="submit">Create license</button>
+  </form>`;
+
+const renderActivationRows = (activations) =>
+  activations
+    .map(
+      (activation) => `
+        <tr>
+          <td><code>${escapeHtml(activation.activationId)}</code></td>
+          <td><code>${escapeHtml(activation.deviceId)}</code></td>
+          <td>${escapeHtml(activation.pluginVersion || "")}</td>
+          <td>${escapeHtml(activation.activatedAt || "")}</td>
+          <td>${escapeHtml(activation.lastSeenAt || "")}</td>
+        </tr>`
+    )
+    .join("");
+
+const renderStatusOptions = (currentStatus) =>
+  ADMIN_LICENSE_STATUSES.map(
+    (status) =>
+      `<option value="${status}"${
+        status === currentStatus ? " selected" : ""
+      }>${status}</option>`
+  ).join("");
+
+const renderLicenseDetail = (license, notice = "") => {
+  const activations = getActivations(license);
+  const status = getLicenseStatus(license);
+
+  return `
+    ${notice ? `<p>${escapeHtml(notice)}</p>` : ""}
+    <dl>
+      <dt>License ID</dt>
+      <dd><code>${escapeHtml(license.licenseId)}</code></dd>
+      <dt>Status</dt>
+      <dd>${escapeHtml(status)}</dd>
+      <dt>Max activations</dt>
+      <dd>${escapeHtml(getMaxActivations(license))}</dd>
+      <dt>Used activations</dt>
+      <dd>${escapeHtml(activations.length)}</dd>
+      <dt>Source</dt>
+      <dd>${escapeHtml(license.source || "")}</dd>
+      <dt>Created at</dt>
+      <dd>${escapeHtml(license.createdAt || "")}</dd>
+      <dt>Updated at</dt>
+      <dd>${escapeHtml(license.updatedAt || "")}</dd>
+    </dl>
+
+    <h2>Activations</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Activation ID</th>
+          <th>Device ID</th>
+          <th>Plugin version</th>
+          <th>Activated at</th>
+          <th>Last seen at</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${
+          activations.length
+            ? renderActivationRows(activations)
+            : '<tr><td colspan="5">No activations yet.</td></tr>'
+        }
+      </tbody>
+    </table>
+
+    <h2>Change Status</h2>
+    <form method="post" action="/admin/licenses/${encodeURIComponent(license.licenseId)}/status">
+      <label for="status">Status</label>
+      <select id="status" name="status">
+        ${renderStatusOptions(status)}
+      </select>
+      <button type="submit">Update status</button>
+    </form>
+
+    <h2>Reset Activations</h2>
+    <form class="danger" method="post" action="/admin/licenses/${encodeURIComponent(license.licenseId)}/reset-activations">
+      <p>This will remove all activation records for this license.</p>
+      <button type="submit">Reset activations</button>
+    </form>`;
+};
+
+const getAdminNotice = (query) => {
+  if (query.created) {
+    return "License created.";
+  }
+
+  if (query.statusUpdated) {
+    return "License status updated.";
+  }
+
+  if (query.activationsReset) {
+    return "Activation records reset.";
+  }
+
+  return "";
+};
 
 const validateLicenseKey = async ({ key, collection, hmacSecret }) => {
   const { value: licenseToValidate, error: keyError } = getValidLicenseKey(key);
@@ -715,6 +998,8 @@ const createApp = ({
   allowedOrigins = parseAllowedOrigins(process.env.ALLOWED_ORIGINS),
   allowNullOrigin = getBoolean(process.env.ALLOW_NULL_ORIGIN),
   trustProxy = shouldTrustProxy(),
+  adminUsername = process.env.ADMIN_USERNAME,
+  adminPassword = process.env.ADMIN_PASSWORD,
 } = {}) => {
   const app = express();
 
@@ -726,6 +1011,7 @@ const createApp = ({
 
   // Enable JSON support
   app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
 
   app.get("/health", (req, res) => {
     const connected = getMongoConnected();
@@ -785,6 +1071,201 @@ const createApp = ({
         code: "INTERNAL_SERVER_ERROR",
       });
     }
+  });
+
+  const getAdminLicensesCollection = async () => {
+    const collection = await getLicensesCollection();
+
+    if (!collection) {
+      return null;
+    }
+
+    return collection;
+  };
+
+  app.use(
+    "/admin",
+    createAdminAuthMiddleware({ adminUsername, adminPassword })
+  );
+
+  app.get("/admin", (req, res) => {
+    res.redirect(303, "/admin/licenses");
+  });
+
+  app.get(
+    "/admin/licenses",
+    asyncRoute(async (req, res) => {
+      const collection = await getAdminLicensesCollection();
+
+      if (!collection) {
+        renderAdminError(res, 503, "Database not ready.");
+        return;
+      }
+
+      const licenses = await collection
+        .find({})
+        .sort({ createdAt: -1 })
+        .limit(100)
+        .toArray();
+
+      sendAdminHtml(res, "Licenses", renderLicenseList(licenses));
+    })
+  );
+
+  app.get("/admin/licenses/new", (req, res) => {
+    sendAdminHtml(res, "Create License", renderNewLicenseForm());
+  });
+
+  app.post(
+    "/admin/licenses",
+    asyncRoute(async (req, res) => {
+      const collection = await getAdminLicensesCollection();
+
+      if (!collection) {
+        renderAdminError(res, 503, "Database not ready.");
+        return;
+      }
+
+      const prefix = String(
+        req.body.prefix || DEFAULT_ADMIN_LICENSE_PREFIX
+      ).toUpperCase();
+      const maxActivations = parsePositiveInteger(
+        req.body.maxActivations || String(DEFAULT_MAX_ACTIVATIONS)
+      );
+      const source = String(
+        req.body.source || DEFAULT_ADMIN_LICENSE_SOURCE
+      ).trim();
+
+      if (!/^[A-Z]{2,10}$/.test(prefix)) {
+        renderAdminError(res, 400, "Prefix must contain 2 to 10 letters.");
+        return;
+      }
+
+      if (!maxActivations) {
+        renderAdminError(res, 400, "Max activations must be a positive integer.");
+        return;
+      }
+
+      if (!source) {
+        renderAdminError(res, 400, "Source is required.");
+        return;
+      }
+
+      const license = await insertLicenseWithRetry({
+        collection,
+        prefix,
+        maxActivations,
+        source,
+      });
+
+      res.redirect(
+        303,
+        `/admin/licenses/${encodeURIComponent(license.licenseId)}?created=1`
+      );
+    })
+  );
+
+  app.get(
+    "/admin/licenses/:licenseId",
+    asyncRoute(async (req, res) => {
+      const collection = await getAdminLicensesCollection();
+
+      if (!collection) {
+        renderAdminError(res, 503, "Database not ready.");
+        return;
+      }
+
+      const license = await collection.findOne({
+        licenseId: req.params.licenseId,
+      });
+
+      if (!license) {
+        renderAdminError(res, 404, "License not found.");
+        return;
+      }
+
+      sendAdminHtml(
+        res,
+        `License ${license.licenseId}`,
+        renderLicenseDetail(license, getAdminNotice(req.query))
+      );
+    })
+  );
+
+  app.post(
+    "/admin/licenses/:licenseId/status",
+    asyncRoute(async (req, res) => {
+      const status = req.body.status;
+
+      if (!ADMIN_LICENSE_STATUSES.includes(status)) {
+        renderAdminError(res, 400, "Invalid license status.");
+        return;
+      }
+
+      const collection = await getAdminLicensesCollection();
+
+      if (!collection) {
+        renderAdminError(res, 503, "Database not ready.");
+        return;
+      }
+
+      const updateResult = await collection.updateOne(
+        { licenseId: req.params.licenseId },
+        {
+          $set: {
+            status,
+            updatedAt: new Date().toISOString(),
+          },
+        }
+      );
+
+      if (!updateResult.matchedCount) {
+        renderAdminError(res, 404, "License not found.");
+        return;
+      }
+
+      res.redirect(
+        303,
+        `/admin/licenses/${encodeURIComponent(req.params.licenseId)}?statusUpdated=1`
+      );
+    })
+  );
+
+  app.post(
+    "/admin/licenses/:licenseId/reset-activations",
+    asyncRoute(async (req, res) => {
+      const collection = await getAdminLicensesCollection();
+
+      if (!collection) {
+        renderAdminError(res, 503, "Database not ready.");
+        return;
+      }
+
+      const updateResult = await collection.updateOne(
+        { licenseId: req.params.licenseId },
+        {
+          $set: {
+            activations: [],
+            updatedAt: new Date().toISOString(),
+          },
+        }
+      );
+
+      if (!updateResult.matchedCount) {
+        renderAdminError(res, 404, "License not found.");
+        return;
+      }
+
+      res.redirect(
+        303,
+        `/admin/licenses/${encodeURIComponent(req.params.licenseId)}?activationsReset=1`
+      );
+    })
+  );
+
+  app.use("/admin", (error, req, res, next) => {
+    console.error("Failed to render admin UI:", error);
+    renderAdminError(res, 500, "Admin request failed.");
   });
 
   return app;


### PR DESCRIPTION
## Summary
- Add a private server-rendered admin UI under `/admin`.
- Protect all admin routes with HTTP Basic Auth using `ADMIN_USERNAME` and `ADMIN_PASSWORD`.
- Add license list, create, detail, status update, and reset activation flows.
- Reuse existing license generation logic so admin-created licenses use the activation document model.
- Update README and AGENTS with admin UI guidance.

## Admin routes
- `GET /admin`
- `GET /admin/licenses`
- `GET /admin/licenses/new`
- `POST /admin/licenses`
- `GET /admin/licenses/:licenseId`
- `POST /admin/licenses/:licenseId/status`
- `POST /admin/licenses/:licenseId/reset-activations`

## Validation
- `node -c index.js`
- `node -c scripts/createLicense.js`
- `git diff --check`
- `npm test` (85 tests passing)

## Notes
- Public activation/validation endpoints are unchanged.
- Manual browser testing was not run because it requires real MongoDB and admin credentials.